### PR TITLE
Fix standard_name in pfp_ts.CorrectFgForStorage().

### DIFF
--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -1,5 +1,7 @@
 version_name = "PyFluxPro"
-version_number = "V3.3.2"
+version_number = "V3.3.3"
+# V3.3.3 - February 2022
+#        - fix standard_name for Fg_Av in pfp_ts.CorrectFgForStorage()
 # V3.3.2 - January 2022
 #        - implement EasyFlux-DL variables in check_l1_controlfile.txt
 # V3.3.1 - November 2021, post workshop bug fixes

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -1352,7 +1352,7 @@ def CorrectFgForStorage(cf, ds, info, Fg_out='Fg', Fg_in='Fg', Ts_in='Ts', Sws_i
     attr = {"long_name": "Ground heat flux",
             descr_level: "Ground heat flux uncorrected for storage",
             "units": "W/m^2", "statistic_type": "average",
-            "standard_name": "downward_heat_flux_in_soil"}
+            "standard_name": "downward_heat_flux_at_ground_level_in_soil"}
     pfp_utils.CreateSeries(ds, "Fg_Av", Fg, Fg_flag, attr)
     flag = numpy.where(numpy.ma.getmaskarray(S) == True, ones, zeros)
     attr = {"long_name": "Ground heat flux storage", "units": "W/m^2",


### PR DESCRIPTION
Wrong standard_name used for Fg_Av in code for pfp_ts.CorrectFgForStorage().