### PR TITLE
Fix extra line in biomet file under Windows.

### DIFF
--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -1236,7 +1236,7 @@ def write_csv_ep_biomet(cf):
     if not pfp_utils.path_exists(os.path.dirname(csvFileName), mode="verbose"):
         return 0
     # open the csv file
-    csvfile = open(csvFileName, "w")
+    csvfile = open(csvFileName, "w", newline="")
     writer = csv.writer(csvfile)
     # read the netCDF file
     ds = NetCDFRead(ncFileName)


### PR DESCRIPTION
Thought I had fixed this ...
Added newline='' option to file open statement when writing the biomet file.