### PR TITLE
Implement reading of biomet and full_output CSV files at L1.

### DIFF
--- a/controlfiles/templates/L1/L1_eddypro_csv.txt
+++ b/controlfiles/templates/L1/L1_eddypro_csv.txt
@@ -1,8 +1,8 @@
 level = L1
 [Files]
     file_path = Right click to browse
-    in_filename = Right click to browse (*.csv)
-    in_firstdatarow = 5
+    in_filename = Right click to browse (*.csv, biomet & full_output)
+    in_firstdatarow = 4
     in_headerrow = 2
     out_filename = Right click to browse (*.nc)
 [Global]
@@ -38,78 +38,63 @@ and the Education Investment Fund.'''
     tower_height = 
     vegetation = 
 [Variables]
-    [[AGC_IRGA]]
-        [[[Attr]]]
-            instrument = <irga_type>
-            long_name = IRGA automatic gain control value
-            statistic_type = average
-            units = 1
-        [[[csv]]]
-            name = AGC_7500_Avg
-    [[AH_<inst>_<height>m]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <instrument_type>
-            long_name = Absolute humidity
-            standard_name = mass_concentration_of_water_vapor_in_air
-            statistic_type = average
-            units = g/m^3
-        [[[csv]]]
-            name = Ah_<inst>_01_Avg
-    [[AH_IRGA_Av]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <irga_type>
-            long_name = Absolute humidity
-            standard_name = mass_concentration_of_water_vapor_in_air
-            statistic_type = average
-            units = g/m^3
-        [[[csv]]]
-            name = Ah_7500_Avg
-    [[AH_IRGA_Vr]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <irga_type>
-            long_name = Absolute humidity
-            statistic_type = variance
-            units = g^2/m^6
-        [[[csv]]]
-            name = covAhAh
     [[CO2_IRGA_Av]]
         [[[Attr]]]
             height = <height>m
             instrument = <irga_type>
             long_name = CO2 concentration
-            standard_name = mass_concentration_of_carbon_dioxide_in_air
+            standard_name = mole_fraction_of_carbon_dioxide_in_air
             statistic_type = average
-            units = mg/m^3
+            units = umol/mol
         [[[csv]]]
-            name = Cc_7500_Avg
+            name = co2_mixing_ratio
     [[CO2_IRGA_Vr]]
         [[[Attr]]]
             height = <height>m
             instrument = <irga_type>
             long_name = CO2 concentration
             statistic_type = variance
-            units = mg^2/m^6
+            units = umol^2/mol^2
         [[[csv]]]
-            name = covCcCc
-    [[Diag_IRGA]]
+            name = co2_var
+    [[Fco2_EP]]
         [[[Attr]]]
-            instrument = <irga_type>
-            long_name = IRGA diagnostic value
+            height = <height>m
+            instrument = <sonic_type>,<irga_type>
+            long_name = CO2 flux
+            standard_name = surface_upward_mole_flux_of_carbon_dioxide
+            statistic_type = average
+            units = umol/m^2/s
+        [[[csv]]]
+            name = co2_flux
+    [[Fco2_EP_QC]]
+        [[[Attr]]]
+            height = <height>m
+            instrument = <sonic_type>,<irga_type>
+            long_name = CO2 flux EddyPro QC flag
             statistic_type = average
             units = 1
         [[[csv]]]
-            name = 7500_Warn
-    [[Diag_SONIC]]
+            name = qc_co2_flux
+    [[Fe_EP]]
         [[[Attr]]]
-            instrument = <sonic_type>
-            long_name = Sonic diagnostic value
+            height = <height>m
+            instrument = <sonic_type>,<irga_type>
+            long_name = Latent heat flux
+            standard_name = surface_upward_latent_heat_flux
+            statistic_type = average
+            units = W/m^2
+        [[[csv]]]
+            name = LE
+    [[Fe_EP_QC]]
+        [[[Attr]]]
+            height = <height>m
+            instrument = <sonic_type>,<irga_type>
+            long_name = Latent heat flux EddyPro QC flag
             statistic_type = average
             units = 1
         [[[csv]]]
-            name = CSAT_Warn
+            name = qc_LE
     [[Fg_<depth>cma]]
         [[[Attr]]]
             height = <depth>m
@@ -119,7 +104,7 @@ and the Education Investment Fund.'''
             statistic_type = average
             units = W/m^2
         [[[csv]]]
-            name = Fg_01_Avg
+            name = SHF_1_1_1
     [[Fg_<depth>cmb]]
         [[[Attr]]]
             height = <depth>m
@@ -129,67 +114,114 @@ and the Education Investment Fund.'''
             statistic_type = average
             units = W/m^2
         [[[csv]]]
-            name = Fg_02_Avg
-    [[Fg_<depth>cmc]]
+            name = SHF_1_1_2
+    [[Fh_EP]]
         [[[Attr]]]
-            height = <depth>m
-            instrument = <instrument_type>
-            long_name = Ground heat flux
-            standard_name = downward_heat_flux_at_ground_level_in_soil
+            height = <height>m
+            instrument = <sonic_type>
+            long_name = Sensible heat flux
+            standard_name = surface_upward_sensible_heat_flux
             statistic_type = average
             units = W/m^2
         [[[csv]]]
-            name = Fg_03_Avg
+            name = H
+    [[Fh_EP_QC]]
+        [[[Attr]]]
+            height = <height>m
+            instrument = <sonic_type>
+            long_name = Sensible heat flux EddyPro QC flag
+            statistic_type = average
+            units = 1
+        [[[csv]]]
+            name = qc_H
     [[Fld]]
         [[[Attr]]]
             height = <height>m
-            instrument = Kipp and Zonen CNR4
+            instrument = Kipp and Zonen CNR1
             long_name = Down-welling longwave radiation
             standard_name = surface_downwelling_longwave_flux_in_air
             statistic_type = average
             units = W/m^2
         [[[csv]]]
-            name = Fld_CNR4_Avg
+            name = LW_IN_1_1_1
     [[Flu]]
         [[[Attr]]]
             height = <height>m
-            instrument = Kipp and Zonen CNR4
+            instrument = Kipp and Zonen CNR1
             long_name = Up-welling longwave radiation
             standard_name = surface_upwelling_longwave_flux_in_air
             statistic_type = average
             units = W/m^2
         [[[csv]]]
-            name = Flu_CNR4_Avg
-    [[Fn_NR]]
+            name = LW_OUT_1_1_1
+    [[Fm_EP]]
         [[[Attr]]]
             height = <height>m
-            instrument = NR Lite
+            instrument = <sonic_type>
+            long_name = Momentum flux
+            standard_name = magnitude_of_surface_downward_stress
+            statistic_type = average
+            units = kg/m/s^2
+        [[[csv]]]
+            name = Tau
+    [[Fm_EP_QC]]
+        [[[Attr]]]
+            height = <height>m
+            instrument = <sonic_type>
+            long_name = Momentum flux EddyPro QC flag
+            statistic_type = average
+            units = 1
+        [[[csv]]]
+            name = qc_Tau
+    [[Fn]]
+        [[[Attr]]]
+            height = <height>m
+            instrument = Kipp and Zonen CNR1
             long_name = Net radiation
             standard_name = surface_net_downward_radiative_flux
             statistic_type = average
             units = W/m^2
         [[[csv]]]
-            name = Fn_NR_Avg
+            name = RN_1_1_1
     [[Fsd]]
         [[[Attr]]]
             height = <height>m
-            instrument = Kipp and Zonen CNR4
+            instrument = Kipp and Zonen CNR1
             long_name = Down-welling shortwave radiation
             standard_name = surface_downwelling_shortwave_flux_in_air
             statistic_type = average
             units = W/m^2
         [[[csv]]]
-            name = Fsd_CNR4_Avg
+            name = SW_IN_1_1_1
     [[Fsu]]
         [[[Attr]]]
             height = <height>m
-            instrument = Kipp and Zonen CNR4
+            instrument = Kipp and Zonen CNR1
             long_name = Up-welling shortwave radiation
             standard_name = surface_upwelling_shortwave_flux_in_air
             statistic_type = average
             units = W/m^2
         [[[csv]]]
-            name = Fsu_CNR4_Avg
+            name = SW_OUT_1_1_1
+    [[H2O_IRGA_Av]]
+        [[[Attr]]]
+            height = <height>m
+            instrument = <irga_type>
+            long_name = H2O concentration
+            standard_name = mole_fraction_of_water_vapor_in_air
+            statistic_type = average
+            units = mmol/mol
+        [[[csv]]]
+            name = h2o_mixing_ratio
+    [[H2O_IRGA_Vr]]
+        [[[Attr]]]
+            height = <height>m
+            instrument = <irga_type>
+            long_name = H2O concentration
+            statistic_type = variance
+            units = mmol^2/mol^2
+        [[[csv]]]
+            name = h2o_var
     [[Precip]]
         [[[Attr]]]
             height = <height>m
@@ -199,7 +231,7 @@ and the Education Investment Fund.'''
             statistic_type = sum
             units = mm
         [[[csv]]]
-            name = Rain_Tot
+            name = P_1_1_1
     [[RH_<inst>_<height>m]]
         [[[Attr]]]
             height = <height>m
@@ -209,7 +241,17 @@ and the Education Investment Fund.'''
             statistic_type = average
             units = percent
         [[[csv]]]
-            name = RH_<inst>_01_Avg
+            name = RH_1_1_1
+    [[RH_IRGA_Av]]
+        [[[Attr]]]
+            height = <height>m
+            instrument = <irga_type>
+            long_name = Relative humidity
+            standard_name = relative_humidity
+            statistic_type = average
+            units = percent
+        [[[csv]]]
+            name = RH
     [[Sws_<depth>cma]]
         [[[Attr]]]
             height = <depth>m
@@ -219,7 +261,7 @@ and the Education Investment Fund.'''
             statistic_type = average
             units = m^3/m^3
         [[[csv]]]
-            name = Sws_01_Avg
+            name = SWC_1_1_1
     [[Sws_<depth>cmb]]
         [[[Attr]]]
             height = <depth>m
@@ -229,17 +271,7 @@ and the Education Investment Fund.'''
             statistic_type = average
             units = m^3/m^3
         [[[csv]]]
-            name = Sws_02_Avg
-    [[Sws_<depth>cmc]]
-        [[[Attr]]]
-            height = <depth>m
-            instrument = <instrument_type>
-            long_name = Soil water content
-            standard_name = volume_fraction_of_condensed_water_in_soil
-            statistic_type = average
-            units = m^3/m^3
-        [[[csv]]]
-            name = Sws_03_Avg
+            name = SWC_1_1_2
     [[Ta_<inst>_<height>m]]
         [[[Attr]]]
             height = <height>m
@@ -247,17 +279,11 @@ and the Education Investment Fund.'''
             long_name = Air temperature
             standard_name = air_temperature
             statistic_type = average
-            units = degC
+            units = K
+        [[[Function]]]
+            func = K_to_C(Ta_<inst>_<height>m)
         [[[csv]]]
-            name = Ta_<inst>_01_Avg
-    [[Tpanel]]
-        [[[Attr]]]
-            instrument = Campbell Scientific CR3000 logger
-            long_name = Panel temperature at logger
-            units = degC
-            statistic_type = average
-        [[[csv]]]
-            name = Tpanel_Avg
+            name = TA_1_1_1
     [[Ts_<depth>cma]]
         [[[Attr]]]
             height = <depth>m
@@ -265,9 +291,11 @@ and the Education Investment Fund.'''
             long_name = Soil temperature
             standard_name = soil_temperature
             statistic_type = average
-            units = degC
+            units = K
+        [[[Function]]]
+            func = K_to_C(Ts_<depth>cma)
         [[[csv]]]
-            name = Ts_01_Avg
+            name = TS_1_1_1
     [[Ts_<depth>cmb]]
         [[[Attr]]]
             height = <depth>m
@@ -275,19 +303,11 @@ and the Education Investment Fund.'''
             long_name = Soil temperature
             standard_name = soil_temperature
             statistic_type = average
-            units = degC
+            units = K
+        [[[Function]]]
+            func = K_to_C(Ts_<depth>cmb)
         [[[csv]]]
-            name = Ts_02_Avg
-    [[Ts_<depth>cmc]]
-        [[[Attr]]]
-            height = <depth>m
-            instrument = <instrument_type>
-            long_name = Soil temperature
-            standard_name = soil_temperature
-            statistic_type = average
-            units = degC
-        [[[csv]]]
-            name = Ts_03_Avg
+            name = TS_1_1_2
     [[Tv_SONIC_Av]]
         [[[Attr]]]
             height = <height>m
@@ -295,188 +315,76 @@ and the Education Investment Fund.'''
             long_name = Virtual temperature
             standard_name = virtual_temperature
             statistic_type = average
-            units = degC
+            units = K
+        [[[Function]]]
+            func = K_to_C(Tv_SONIC_Av)
         [[[csv]]]
-            name = Tv_CSAT_Avg
+            name = sonic_temperature
     [[Tv_SONIC_Vr]]
         [[[Attr]]]
             height = <height>m
             instrument = <sonic_type>
             long_name = Virtual temperature
             statistic_type = variance
-            units = degC^2
+            units = K^2
         [[[csv]]]
-            name = covTvTv
-    [[UxA]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>,<irga_type>
-            long_name = Covariance of Ux and H2O
-            statistic_type = average
-            units = g/m^2/s
-        [[[csv]]]
-            name = covUxAh
-    [[UxC]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>,<irga_type>
-            long_name = Covariance of Ux and CO2
-            statistic_type = average
-            units = mg/m^2/s
-        [[[csv]]]
-            name = covUxCc
-    [[UxT]]
+            name = ts_var
+    [[U_SONIC_Av]]
         [[[Attr]]]
             height = <height>m
             instrument = <sonic_type>
-            long_name = Covariance of Ux and T
-            statistic_type = average
-            units = m.degC/s
-        [[[csv]]]
-            name = covUxTv
-    [[UxUy]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>
-            long_name = Covariance of Ux and Uy
-            statistic_type = average
-            units = m^2/s^2
-        [[[csv]]]
-            name = covUxUy
-    [[UxUz]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>
-            long_name = Covariance of Ux and Uz
-            statistic_type = average
-            units = m^2/s^2
-        [[[csv]]]
-            name = covUzUx
-    [[Ux_SONIC_Av]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>
-            long_name = Longitudinal wind velocity component, sonic coordinates
+            long_name = Along wind velocity component
+            standard_name = eastward_wind
             statistic_type = average
             units = m/s
         [[[csv]]]
-            name = Ux_CSAT_Avg
-    [[Ux_SONIC_Vr]]
+            name = u_rot
+    [[U_SONIC_Vr]]
         [[[Attr]]]
             height = <height>m
             instrument = <sonic_type>
-            long_name = Longitudinal wind velocity component, sonic coordinates
+            long_name = Along wind velocity component
             statistic_type = variance
             units = m^2/s^2
         [[[csv]]]
-            name = covUxUx
-    [[UyA]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>,<irga_type>
-            long_name = Covariance of Uy and H2O
-            statistic_type = average
-            units = g/m^2/s
-        [[[csv]]]
-            name = covUyAh
-    [[UyC]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>,<irga_type>
-            long_name = Covariance of Uy and CO2
-            statistic_type = average
-            units = mg/m^2/s
-        [[[csv]]]
-            name = covUyCc
-    [[UyT]]
+            name = u_var
+    [[V_SONIC_Av]]
         [[[Attr]]]
             height = <height>m
             instrument = <sonic_type>
-            long_name = Covariance of Uy and T
-            statistic_type = average
-            units = m.degC/s
-        [[[csv]]]
-            name = covUyTv
-    [[UyUz]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>
-            long_name = Covariance of Uy and Uz
-            statistic_type = average
-            units = m^2/s^2
-        [[[csv]]]
-            name = covUzUy
-    [[Uy_SONIC_Av]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>
-            long_name = Lateral wind velocity component, sonic coordinates
+            long_name = Across wind velocity component
+            standard_name = northward_wind
             statistic_type = average
             units = m/s
         [[[csv]]]
-            name = Uy_CSAT_Avg
-    [[Uy_SONIC_Vr]]
+            name = v_rot
+    [[V_SONIC_Vr]]
         [[[Attr]]]
             height = <height>m
             instrument = <sonic_type>
-            long_name = Lateral wind velocity component, sonic coordinates
+            long_name = Across wind velocity component
             statistic_type = variance
             units = m^2/s^2
         [[[csv]]]
-            name = covUyUy
-    [[UzA]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>,<irga_type>
-            long_name = Covariance of Uz and H2O
-            statistic_type = average
-            units = g/m^2/s
-        [[[csv]]]
-            name = covUzAh
-    [[UzC]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>,<irga_type>
-            long_name = Covariance of Uz and CO2
-            statistic_type = average
-            units = mg/m^2/s
-        [[[csv]]]
-            name = covUzCc
-    [[UzT]]
+            name = v_var
+    [[W_SONIC_Av]]
         [[[Attr]]]
             height = <height>m
             instrument = <sonic_type>
-            long_name = Covariance of Uz and T
-            statistic_type = average
-            units = m.degC/s
-        [[[csv]]]
-            name = covUzTv
-    [[Uz_SONIC_Av]]
-        [[[Attr]]]
-            height = <height>m
-            instrument = <sonic_type>
-            long_name = Vertical wind velocity component, sonic coordinates
+            long_name = Vertical wind velocity component
             statistic_type = average
             units = m/s
         [[[csv]]]
-            name = Uz_CSAT_Avg
-    [[Uz_SONIC_Vr]]
+            name = w_rot
+    [[W_SONIC_Vr]]
         [[[Attr]]]
             height = <height>m
             instrument = <sonic_type>
-            long_name = Vertical wind velocity component, sonic coordinates
+            long_name = Vertical wind velocity component
             statistic_type = variance
             units = m^2/s^2
         [[[csv]]]
-            name = covUzUz
-    [[Vbat]]
-        [[[Attr]]]
-            instrument = Campbell Scientific CR3000 logger
-            long_name = Battery voltage at logger
-            units = V
-            statistic_type = average
-        [[[csv]]]
-            name = Vbat_Avg
+            name = w_var
     [[Wd_<inst>_Av]]
         [[[Attr]]]
             height = <height>m
@@ -486,7 +394,7 @@ and the Education Investment Fund.'''
             statistic_type = average
             units = degrees
         [[[csv]]]
-            name = WD_<inst>_Avg
+            name = WD_1_1_1
     [[Wd_SONIC_Av]]
         [[[Attr]]]
             height = <height>m
@@ -496,7 +404,7 @@ and the Education Investment Fund.'''
             statistic_type = average
             units = degrees
         [[[csv]]]
-            name = WD_CSAT_Compass_Avg
+            name = wind_dir
     [[Ws_<inst>_Av]]
         [[[Attr]]]
             height = <height>m
@@ -506,7 +414,7 @@ and the Education Investment Fund.'''
             statistic_type = average
             units = m/s
         [[[csv]]]
-            name = WS_<inst>_Avg
+            name = WS_1_1_1
     [[Ws_SONIC_Av]]
         [[[Attr]]]
             height = <height>m
@@ -516,14 +424,25 @@ and the Education Investment Fund.'''
             statistic_type = average
             units = m/s
         [[[csv]]]
-            name = WS_CSAT_Avg
+            name = wind_speed
     [[ps]]
         [[[Attr]]]
             height = <height>m
-            instrument = <instrument_type>
+            instrument = <irga_type>
             long_name = Surface air pressure
             standard_name = surface_air_pressure
             statistic_type = average
-            units = kPa
+            units = Pa
+        [[[Function]]]
+            func = Pa_to_kPa(ps)
         [[[csv]]]
-            name = ps_7500_Avg
+            name = air_pressure
+    [[ustar]]
+        [[[Attr]]]
+            height = <height>m
+            instrument = <sonic_type>
+            long_name = Friction velocity
+            statistic_type = average
+            units = m/s
+        [[[csv]]]
+            name = u*

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -535,8 +535,8 @@ def ParseL1ControlFile(cf):
     # copy the files section from the control file
     l1ire["Files"] = copy.deepcopy(cf["Files"])
     l1ire["Files"]["file_name"] = os.path.join(cf["Files"]["file_path"], cf["Files"]["in_filename"])
-    l1ire["Files"]["in_headerrow"] = int(cf["Files"]["in_headerrow"])
-    l1ire["Files"]["in_firstdatarow"] = int(cf["Files"]["in_firstdatarow"])
+    l1ire["Files"]["in_headerrow"] = cf["Files"]["in_headerrow"]
+    l1ire["Files"]["in_firstdatarow"] = cf["Files"]["in_firstdatarow"]
     # get the global attributes
     l1ire["Global"] = copy.deepcopy(cf["Global"])
     # get the variables
@@ -910,38 +910,42 @@ def l1_check_files(cfg, std, messages):
             messages["ERROR"].append(msg)
         # check in_filename is in the Files section
         if "in_filename" in cfg["Files"]:
-            file_name = cfg["Files"]["in_filename"]
-            file_parts = os.path.splitext(file_name)
-            # check the file type is supported
-            if (file_parts[-1].lower() in  [".xls", ".xlsx", ".csv"]):
-                file_uri = os.path.join(file_path, file_name)
-                if os.path.isfile(file_uri):
-                    pass
+            file_names = cfg["Files"]["in_filename"]
+            file_names = file_names.split(",")
+            for file_name in file_names:
+                file_parts = os.path.splitext(file_name)
+                # check the file type is supported
+                if (file_parts[-1].lower() in  [".xls", ".xlsx", ".csv"]):
+                    file_uri = os.path.join(file_path, file_name)
+                    if os.path.isfile(file_uri):
+                        pass
+                    else:
+                        msg = "Files: " + file_name + " not found"
+                        messages["ERROR"].append(msg)
                 else:
-                    msg = "Files: " + file_name + " not found"
+                    msg = "Files: " + file_name + " doesn't end with .xls, .xlsx or .csv"
                     messages["ERROR"].append(msg)
-            else:
-                msg = "Files: " + file_name + " doesn't end with .xls, .xlsx or .csv"
-                messages["ERROR"].append(msg)
         else:
             msg = "Files: 'in_filename' not in section"
             messages["ERROR"].append(msg)
         # check in_firstdatarow is in the Files section
         if "in_firstdatarow" in cfg["Files"]:
-            # check to see if in_firdtdatarow is an integer
-            try:
-                i = int(cfg["Files"]["in_firstdatarow"])
-            except:
-                msg = "Files: 'in_firstdatarow' is not an integer"
-                messages["ERROR"].append(msg)
+            for item in cfg["Files"]["in_firstdatarow"].split(","):
+                # check to see if in_firdtdatarow is an integer
+                try:
+                    i = int(item)
+                except:
+                    msg = "Files: 'in_firstdatarow' is not an integer"
+                    messages["ERROR"].append(msg)
         # check in_headerrow is in the Files section
         if "in_headerrow" in cfg["Files"]:
-            # check to see if in_heafderrow is an integer
-            try:
-                i = int(cfg["Files"]["in_headerrow"])
-            except:
-                msg = "Files: 'in_headerrow' is not an integer"
-                messages["ERROR"].append(msg)
+            for item in cfg["Files"]["in_headerrow"].split(","):
+                # check to see if in_heafderrow is an integer
+                try:
+                    i = int(item)
+                except:
+                    msg = "Files: 'in_headerrow' is not an integer"
+                    messages["ERROR"].append(msg)
         # check the output file type
         if "out_filename" in cfg["Files"]:
             file_name = cfg["Files"]["out_filename"]


### PR DESCRIPTION
PFP will now read a biomet and a full_output CSV file at L1 and produce a single netCDF file.  This avoids having to import the biomet and full_output CSV files into Excel and then combining the date and time columns into a single TIMESTAMP column.
It works by selecting the biomet and full_output files when browsing for in_filename in the Files section.  If the selected CSV files contain "biomet" and "full_output" in their file names, the in_firstdatarow and in_headerrow entries are automagically updated.  PFP does some basic checking of file types and number of files selected so that only 1 .xls or ,xlsx file can be chosen and if 2 .csv files are chosen, they must contain 'biomet' and 'full_output' in their file names.