### PR TITLE
Fix l3 disable wpl

### DIFF
--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -742,7 +742,9 @@ class pfp_main_ui(QWidget):
                 pfp_top_level.do_run_l1(cfg)
             self.actionRunCurrent.setDisabled(False)
         elif cfg["level"] == "L2":
-            pfp_top_level.do_run_l2(cfg)
+            # check the L2 control file to see if it is OK to run
+            if pfp_compliance.check_l2_controlfile(cfg):
+                pfp_top_level.do_run_l2(cfg)
             self.actionRunCurrent.setDisabled(False)
         elif cfg["level"] == "L3":
             pfp_top_level.do_run_l3(cfg)

--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -112,8 +112,11 @@ class pfp_main_ui(QWidget):
         self.actionStopCurrent = QAction(self)
         self.actionStopCurrent.setText("Stop run")
         # Plot menu items
-        self.actionPlotFcVersusUstar = QAction(self)
-        self.actionPlotFcVersusUstar.setText("Fco2 vs u*")
+        #self.actionPlotFcVersusUstar = QAction(self)
+        #self.actionPlotFcVersusUstar.setText("Fco2 vs u*")
+        # Plot Fco2 vs u* submenu
+        self.menuPlotFco2vsUstar = QMenu(self.menuPlot)
+        self.menuPlotFco2vsUstar.setTitle("Fco2 vs u*")
         self.actionPlotFingerprints = QAction(self)
         self.actionPlotFingerprints.setText("Fingerprints")
         self.actionPlotQuickCheck = QAction(self)
@@ -124,6 +127,13 @@ class pfp_main_ui(QWidget):
         self.actionPlotWindrose.setText("Windrose")
         self.actionPlotClosePlots = QAction(self)
         self.actionPlotClosePlots.setText("Close plots")
+        # Plot Fco2 vs u* submenu
+        self.actionPlotFco2vsUstar_annual = QAction(self)
+        self.actionPlotFco2vsUstar_annual.setText("Annual")
+        self.actionPlotFco2vsUstar_seasonal = QAction(self)
+        self.actionPlotFco2vsUstar_seasonal.setText("Seasonal")
+        self.actionPlotFco2vsUstar_monthly = QAction(self)
+        self.actionPlotFco2vsUstar_monthly.setText("Monthly")
         # Utilities menu
         self.actionUtilitiesClimatology = QAction(self)
         self.actionUtilitiesClimatology.setText("Climatology")
@@ -156,8 +166,13 @@ class pfp_main_ui(QWidget):
         # Run menu
         self.menuRun.addAction(self.actionRunCurrent)
         self.menuRun.addAction(self.actionRunClearLogWindow)
+        # Plot Fco2 vs u* submenu
+        self.menuPlotFco2vsUstar.addAction(self.actionPlotFco2vsUstar_annual)
+        self.menuPlotFco2vsUstar.addAction(self.actionPlotFco2vsUstar_seasonal)
+        self.menuPlotFco2vsUstar.addAction(self.actionPlotFco2vsUstar_monthly)
         # Plot menu
-        self.menuPlot.addAction(self.actionPlotFcVersusUstar)
+        #self.menuPlot.addAction(self.actionPlotFcVersusUstar)
+        self.menuPlot.addAction(self.menuPlotFco2vsUstar.menuAction())
         self.menuPlot.addAction(self.actionPlotFingerprints)
         self.menuPlot.addAction(self.actionPlotQuickCheck)
         self.menuPlot.addAction(self.actionPlotTimeSeries)
@@ -224,7 +239,9 @@ class pfp_main_ui(QWidget):
         self.actionRunCurrent.triggered.connect(self.run_current)
         self.actionRunClearLogWindow.triggered.connect(self.run_clear_log_window)
         # Plot menu actions
-        self.actionPlotFcVersusUstar.triggered.connect(pfp_top_level.do_plot_fcvsustar)
+        self.actionPlotFco2vsUstar_annual.triggered.connect(pfp_top_level.do_plot_fcvsustar_annual)
+        self.actionPlotFco2vsUstar_seasonal.triggered.connect(pfp_top_level.do_plot_fcvsustar_seasonal)
+        self.actionPlotFco2vsUstar_monthly.triggered.connect(pfp_top_level.do_plot_fcvsustar_monthly)
         self.actionPlotFingerprints.triggered.connect(pfp_top_level.do_plot_fingerprints)
         self.actionPlotQuickCheck.triggered.connect(pfp_top_level.do_plot_quickcheck)
         self.actionPlotTimeSeries.triggered.connect(pfp_top_level.do_plot_timeseries)

--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -787,9 +787,8 @@ class pfp_main_ui(QWidget):
                 pfp_top_level.do_run_l5(self)
             self.actionRunCurrent.setDisabled(False)
         elif cfg["level"] == "L6":
-            if not pfp_compliance.check_l6_controlfile(cfg):
-                return
-            pfp_top_level.do_run_l6(self)
+            if pfp_compliance.check_l6_controlfile(cfg):
+                pfp_top_level.do_run_l6(self)
             self.actionRunCurrent.setDisabled(False)
         elif cfg["level"] == "nc2csv_biomet":
             pfp_top_level.do_file_convert_nc2biomet(self, mode="custom")

--- a/controlfiles/standard/update_control_files.txt
+++ b/controlfiles/standard/update_control_files.txt
@@ -119,6 +119,10 @@ Ta,Ts,ustar,U_,V_,VP,VPD,W_,Wd,Ws"""
         Diag_CSAT = Diag_SONIC
         e = VP
         esat = VPsat
+        # rename CO2 storage terms
+        Fco2_profile = Sco2_profile
+        Fco2_single = Sco2_single
+        Fco2_storage = Sco2
         Fco2_EPFlag = Fco2_EP_QC
         Fc_EPFlag = Fco2_EP_QC
         Fe_EPFlag = Fe_EP_QC
@@ -532,6 +536,12 @@ Friction velocity"""
         [[[xl]]]
             name = H2O_sig_strgth_Min
             sheet = CSFormat
+        [[[Sco2_profile]]]
+            long_name = CO2 flux storage term
+        [[[Sco2_single]]]
+            long_name = CO2 flux storage term
+        [[[Sco2_storage]]]
+            long_name = CO2 flux storage term
         [[[Sws]]]
             long_name = Soil water content
             standard_name = volume_fraction_of_condensed_water_in_soil

--- a/controlfiles/standard/update_control_files.txt
+++ b/controlfiles/standard/update_control_files.txt
@@ -74,7 +74,7 @@ xl_filename,xl_moddatetime"""
     L2 = irga_type,SONIC_Check,IRGA_Check
     L3 = """zms,UseL2Fluxes,2DCoordRotation,MassmanCorrection,ApplyFco2Storage,
 ApplyFcStorage,CorrectIndividualFg,CorrectFgForStorage,KeepIntermediateSeries,CO2Units,
-Fco2Units,FcUnits"""
+Fco2Units,FcUnits,DisableFco2WPL,DisableFcWPL,DisableFeWPL,DisableWPL"""
     concatenate = """NumberOfDimensions,MaxGapInterpolate,FixTimeStepMethod,
 Truncate,DoFingerprints,TruncateThreshold,SeriesToCheck"""
     cpd_barr = Fsd_threshold,Num_bootstraps

--- a/controlfiles/standard/update_control_files.txt
+++ b/controlfiles/standard/update_control_files.txt
@@ -73,8 +73,9 @@ xl_filename,xl_moddatetime"""
 [Options]
     L2 = irga_type,SONIC_Check,IRGA_Check
     L3 = """zms,UseL2Fluxes,2DCoordRotation,MassmanCorrection,ApplyFco2Storage,
-ApplyFcStorage,CorrectIndividualFg,CorrectFgForStorage,KeepIntermediateSeries,CO2Units,
-Fco2Units,FcUnits,DisableFco2WPL,DisableFcWPL,DisableFeWPL,DisableWPL,ApplyWPL"""
+ApplyFcStorage,CorrectIndividualFg,CorrectFgForStorage,KeepIntermediateSeries,
+CcUnits, CO2Units, Fco2Units,FcUnits,DisableFco2WPL,DisableFcWPL,DisableFeWPL,
+DisableWPL,ApplyWPL"""
     concatenate = """NumberOfDimensions,MaxGapInterpolate,FixTimeStepMethod,
 Truncate,DoFingerprints,TruncateThreshold,SeriesToCheck"""
     cpd_barr = Fsd_threshold,Num_bootstraps

--- a/controlfiles/standard/update_control_files.txt
+++ b/controlfiles/standard/update_control_files.txt
@@ -74,7 +74,7 @@ xl_filename,xl_moddatetime"""
     L2 = irga_type,SONIC_Check,IRGA_Check
     L3 = """zms,UseL2Fluxes,2DCoordRotation,MassmanCorrection,ApplyFco2Storage,
 ApplyFcStorage,CorrectIndividualFg,CorrectFgForStorage,KeepIntermediateSeries,CO2Units,
-Fco2Units,FcUnits,DisableFco2WPL,DisableFcWPL,DisableFeWPL,DisableWPL"""
+Fco2Units,FcUnits,DisableFco2WPL,DisableFcWPL,DisableFeWPL,DisableWPL,ApplyWPL"""
     concatenate = """NumberOfDimensions,MaxGapInterpolate,FixTimeStepMethod,
 Truncate,DoFingerprints,TruncateThreshold,SeriesToCheck"""
     cpd_barr = Fsd_threshold,Num_bootstraps

--- a/controlfiles/standard/update_control_files.txt
+++ b/controlfiles/standard/update_control_files.txt
@@ -71,16 +71,11 @@ xl_filename,xl_moddatetime"""
         Yanco = AU-Ync
 
 [Options]
-    L2 = irga_type,SONIC_Check,IRGA_Check
-    L3 = """zms,UseL2Fluxes,2DCoordRotation,MassmanCorrection,ApplyFco2Storage,
-<<<<<<< HEAD
-ApplyFcStorage,CorrectIndividualFg,CorrectFgForStorage,KeepIntermediateSeries,CO2Units,
-Fco2Units,FcUnits,DisableFco2WPL,DisableFcWPL,DisableFeWPL,DisableWPL,ApplyWPL"""
-=======
-ApplyFcStorage,CorrectIndividualFg,CorrectFgForStorage,KeepIntermediateSeries,
-CcUnits, CO2Units, Fco2Units,FcUnits,DisableFco2WPL,DisableFcWPL,DisableFeWPL,
-DisableWPL,ApplyWPL"""
->>>>>>> 6435089820f1be4f18cd909f9c5095557a9968ec
+    L2 = irga_type,sonic_type,SONIC_Check,IRGA_Check
+    L3 = """zms,UseL2Fluxes,CalculateFluxes,2DCoordRotation,MassmanCorrection,
+ApplyFco2Storage,ApplyFcStorage,CorrectIndividualFg,CorrectFgForStorage,
+KeepIntermediateSeries,CcUnits, CO2Units, Fco2Units,FcUnits,DisableFco2WPL,
+DisableFcWPL,DisableFeWPL,DisableWPL,ApplyWPL"""
     concatenate = """NumberOfDimensions,MaxGapInterpolate,FixTimeStepMethod,
 Truncate,DoFingerprints,TruncateThreshold,SeriesToCheck"""
     cpd_barr = Fsd_threshold,Num_bootstraps

--- a/controlfiles/templates/L2/L2_ozflux.txt
+++ b/controlfiles/templates/L2/L2_ozflux.txt
@@ -5,7 +5,8 @@ level = L2
     out_filename = Right click to browse (*.nc)
     plot_path = Right click to browse
 [Options]
-    irga_type = Li-7500
+    irga_type = Li-7500A
+    sonic_type = CSAT3
     SONIC_Check = Yes
     IRGA_Check = Yes
 [Variables]

--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -4,6 +4,7 @@ version_number = "V3.4.8"
 #        - implement check of IRGA type at L2
 #        - imlement check of IRGA type at L3
 #          - warn user if irga_type in ["EC155", "Li-7200"] and ApplyWPL=Yes
+#        - tidy up Fco2 vs u* plotting
 # V3.4.7 - September 2022
 #        - tidied up removal of intermediate series at L6
 # V3.4.6 - August 2022

--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -3,7 +3,7 @@ version_number = "V3.4.8"
 # V3.4.8 - October 2022
 #        - implement check of IRGA type at L2
 #        - imlement check of IRGA type at L3
-#          - warn user if irga_type in ["EC155", "Li-7200"] and DisableWPL=No
+#          - warn user if irga_type in ["EC155", "Li-7200"] and ApplyWPL=Yes
 # V3.4.7 - September 2022
 #        - tidied up removal of intermediate series at L6
 # V3.4.6 - August 2022

--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -1,5 +1,9 @@
 version_name = "PyFluxPro"
-version_number = "V3.4.7"
+version_number = "V3.4.8"
+# V3.4.8 - October 2022
+#        - implement check of IRGA type at L2
+#        - imlement check of IRGA type at L3
+#          - warn user if irga_type in ["EC155", "Li-7200"] and DisableWPL=No
 # V3.4.7 - September 2022
 #        - tidied up removal of intermediate series at L6
 # V3.4.6 - August 2022

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -31,7 +31,9 @@ T0   = -46.02  # zero temp[erature in the Lloyd-Taylor respiration equation, deg
 Tb = 1800      # 30-min period, seconds
 C2K = 273.15   # convert degrees celsius to kelvin
 # dictionary of instrument characteristics
-# used in pfp_ts.MassmanStandard()
+# used in pfp_ts.MassmanStandard(), pfp_compliance.l1_check_sonic_type() and
+# pfp_compliance.l1_check_irga_type()
+# 'no_sonic' is for IRGAs used in profile measurements
 instruments = {"sonics": {"CSAT3": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115},
                           "CSAT3A": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115},
                           "CSAT3B": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115}},
@@ -42,7 +44,8 @@ instruments = {"sonics": {"CSAT3": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.11
                                        "IRGASON": {"dIRGA": 0.01, "lIRGA": 0.154}},
                          "closed_path": {"Li-7200": {"dIRGA": 0.0064, "lIRGA": 0.125},
                                          "Li-7200RS": {"dIRGA": 0.0064, "lIRGA": 0.125},
-                                         "EC155": {"dIRGA": 0.008, "lIRGA": 0.120},}}}
+                                         "EC155": {"dIRGA": 0.008, "lIRGA": 0.120},
+                                         "Li-840": {"dIRGA": None, "lIRGA": None}}}}
 # dictionary of site names and time zones
 tz_dict = {"adelaideriver":"Australia/Darwin",
            "alicespringsmulga":"Australia/Darwin",

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -28,13 +28,6 @@ Pi = 3.14159   # Pi
 sb = 5.6704E-8 # Stefan-Boltzman constant, W/m^2/K^4
 Tref = 15.0    # reference temperature in the Lloyd-Taylor respiration equation, degC
 T0   = -46.02  # zero temp[erature in the Lloyd-Taylor respiration equation, degC
-
-lwVert = 0.115       # vertical path length of CSAT3, m
-lwHor = 0.058      # horizontal path length of CSAT3, m
-lTv = 0.115      # path length of sonic virtual temperature, m
-dIRGA = 0.0095 # path diameter of LI7500 IRGA, m
-lIRGA = 0.127  # path length of LI7500 IRGA, m
-
 Tb = 1800      # 30-min period, seconds
 C2K = 273.15   # convert degrees celsius to kelvin
 # dictionary of sonic and IRGA dimensions

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -30,18 +30,18 @@ Tref = 15.0    # reference temperature in the Lloyd-Taylor respiration equation,
 T0   = -46.02  # zero temp[erature in the Lloyd-Taylor respiration equation, degC
 Tb = 1800      # 30-min period, seconds
 C2K = 273.15   # convert degrees celsius to kelvin
-# dictionary of sonic and IRGA dimensions
+# dictionary of instrument characteristics
 # used in pfp_ts.MassmanStandard()
-dims = {"CSAT3": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115},
-        "CSAT3B": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115},
-        "Li-7500": {"dIRGA": 0.0095, "lIRGA": 0.127},
-        "Li-7500A": {"dIRGA": 0.0095, "lIRGA": 0.127},
-        "Li-7500RS": {"dIRGA": 0.0095, "lIRGA": 0.127},
-        "Li-7200": {"dIRGA": 0.0064, "lIRGA": 0.125},
-        "Li-7200RS": {"dIRGA": 0.0064, "lIRGA": 0.125},
-        "EC150": {"dIRGA": 0.01, "lIRGA": 0.154},
-        "EC155": {"dIRGA": 0.008, "lIRGA": 0.120},
-        "IRGASON": {"dIRGA": 0.01, "lIRGA": 0.154}}
+instruments = {"sonics": {"CSAT3": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115},
+                          "CSAT3B": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115}},
+               "irgas": {"open_path": {"Li-7500": {"dIRGA": 0.0095, "lIRGA": 0.127},
+                                       "Li-7500A": {"dIRGA": 0.0095, "lIRGA": 0.127},
+                                       "Li-7500RS": {"dIRGA": 0.0095, "lIRGA": 0.127},
+                                       "EC150": {"dIRGA": 0.01, "lIRGA": 0.154},
+                                       "IRGASON": {"dIRGA": 0.01, "lIRGA": 0.154}},
+                         "closed_path": {"Li-7200": {"dIRGA": 0.0064, "lIRGA": 0.125},
+                                         "Li-7200RS": {"dIRGA": 0.0064, "lIRGA": 0.125},
+                                         "EC155": {"dIRGA": 0.008, "lIRGA": 0.120},}}}
 # dictionary of site names and time zones
 tz_dict = {"adelaideriver":"Australia/Darwin",
            "alicespringsmulga":"Australia/Darwin",

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -33,6 +33,7 @@ C2K = 273.15   # convert degrees celsius to kelvin
 # dictionary of instrument characteristics
 # used in pfp_ts.MassmanStandard()
 instruments = {"sonics": {"CSAT3": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115},
+                          "CSAT3A": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115},
                           "CSAT3B": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115}},
                "irgas": {"open_path": {"Li-7500": {"dIRGA": 0.0095, "lIRGA": 0.127},
                                        "Li-7500A": {"dIRGA": 0.0095, "lIRGA": 0.127},

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -28,13 +28,27 @@ Pi = 3.14159   # Pi
 sb = 5.6704E-8 # Stefan-Boltzman constant, W/m^2/K^4
 Tref = 15.0    # reference temperature in the Lloyd-Taylor respiration equation, degC
 T0   = -46.02  # zero temp[erature in the Lloyd-Taylor respiration equation, degC
+
 lwVert = 0.115       # vertical path length of CSAT3, m
 lwHor = 0.058      # horizontal path length of CSAT3, m
 lTv = 0.115      # path length of sonic virtual temperature, m
 dIRGA = 0.0095 # path diameter of LI7500 IRGA, m
 lIRGA = 0.127  # path length of LI7500 IRGA, m
+
 Tb = 1800      # 30-min period, seconds
 C2K = 273.15   # convert degrees celsius to kelvin
+# dictionary of sonic and IRGA dimensions
+# used in pfp_ts.MassmanStandard()
+dims = {"CSAT3": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115},
+        "CSAT3B": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.115},
+        "Li-7500": {"dIRGA": 0.0095, "lIRGA": 0.127},
+        "Li-7500A": {"dIRGA": 0.0095, "lIRGA": 0.127},
+        "Li-7500RS": {"dIRGA": 0.0095, "lIRGA": 0.127},
+        "Li-7200": {"dIRGA": 0.0064, "lIRGA": 0.125},
+        "Li-7200RS": {"dIRGA": 0.0064, "lIRGA": 0.125},
+        "EC150": {"dIRGA": 0.01, "lIRGA": 0.154},
+        "EC155": {"dIRGA": 0.008, "lIRGA": 0.120},
+        "IRGASON": {"dIRGA": 0.01, "lIRGA": 0.154}}
 # dictionary of site names and time zones
 tz_dict = {"adelaideriver":"Australia/Darwin",
            "alicespringsmulga":"Australia/Darwin",

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -45,7 +45,8 @@ instruments = {"sonics": {"CSAT3": {"lwVert": 0.115, "lwHor": 0.058, "lTv": 0.11
                          "closed_path": {"Li-7200": {"dIRGA": 0.0064, "lIRGA": 0.125},
                                          "Li-7200RS": {"dIRGA": 0.0064, "lIRGA": 0.125},
                                          "EC155": {"dIRGA": 0.008, "lIRGA": 0.120},
-                                         "Li-840": {"dIRGA": None, "lIRGA": None}}}}
+                                         "Li-840": {"dIRGA": None, "lIRGA": None},
+                                         "None": {"dIRGA": None, "lIRGA": None}}}}
 # dictionary of site names and time zones
 tz_dict = {"adelaideriver":"Australia/Darwin",
            "alicespringsmulga":"Australia/Darwin",

--- a/scripts/pfp_batch.py
+++ b/scripts/pfp_batch.py
@@ -88,7 +88,11 @@ def do_L2_batch(main_ui, cf_level):
             cf_l2["Options"]["show_plots"] = "No"
             infilename = pfp_io.get_infilenamefromcf(cf_l2)
             ds1 = pfp_io.NetCDFRead(infilename)
-            if ds1.info["returncodes"]["value"] != 0: return
+            if ds1.info["returncodes"]["value"] != 0:
+                return
+            pfp_compliance.check_l2_options(cf_l2, ds2)
+            if ds2.info["returncodes"]["value"] != 0:
+                return
             ds2 = pfp_levels.l2qc(cf_l2, ds1)
             outfilename = pfp_io.get_outfilenamefromcf(cf_l2)
             pfp_io.NetCDFWrite(outfilename, ds2)
@@ -137,7 +141,11 @@ def do_L3_batch(main_ui, cf_level):
             cf_l3["Options"]["show_plots"] = "No"
             infilename = pfp_io.get_infilenamefromcf(cf_l3)
             ds2 = pfp_io.NetCDFRead(infilename)
-            if ds2.info["returncodes"]["value"] != 0: return
+            if ds2.info["returncodes"]["value"] != 0:
+                return
+            pfp_compliance.check_l3_options(cf_l3, ds2)
+            if ds2.info["returncodes"]["value"] != 0:
+                return
             ds3 = pfp_levels.l3qc(cf_l3, ds2)
             outfilename = pfp_io.get_outfilenamefromcf(cf_l3)
             pfp_io.NetCDFWrite(outfilename, ds3)

--- a/scripts/pfp_batch.py
+++ b/scripts/pfp_batch.py
@@ -90,8 +90,8 @@ def do_L2_batch(main_ui, cf_level):
             ds1 = pfp_io.NetCDFRead(infilename)
             if ds1.info["returncodes"]["value"] != 0:
                 return
-            pfp_compliance.check_l2_options(cf_l2, ds2)
-            if ds2.info["returncodes"]["value"] != 0:
+            pfp_compliance.check_l2_options(cf_l2, ds1)
+            if ds1.info["returncodes"]["value"] != 0:
                 return
             ds2 = pfp_levels.l2qc(cf_l2, ds1)
             outfilename = pfp_io.get_outfilenamefromcf(cf_l2)

--- a/scripts/pfp_batch.py
+++ b/scripts/pfp_batch.py
@@ -54,12 +54,16 @@ def do_L1_batch(main_ui, cf_level):
             cf_l1 = pfp_io.get_controlfilecontents(cf_level[i])
             if not pfp_compliance.l1_update_controlfile(cf_l1):
                 continue
-            ds1 = pfp_levels.l1qc(cf_l1)
-            outfilename = pfp_io.get_outfilenamefromcf(cf_l1)
-            pfp_io.NetCDFWrite(outfilename, ds1)
-            msg = "Finished L1 processing with " + cf_file_name[1]
-            logger.info(msg)
-            logger.info("")
+            if pfp_compliance.check_l1_controlfile(cf_l1):
+                ds1 = pfp_levels.l1qc(cf_l1)
+                outfilename = pfp_io.get_outfilenamefromcf(cf_l1)
+                pfp_io.NetCDFWrite(outfilename, ds1)
+                msg = "Finished L1 processing with " + cf_file_name[1]
+                logger.info(msg)
+                logger.info("")
+            else:
+                msg = "Error occurred checking compliance of L1 controlfile"
+                logger.error(msg)
         except Exception:
             msg = "Error occurred during L1 processing " + cf_file_name[1]
             logger.error(msg)
@@ -93,26 +97,30 @@ def do_L2_batch(main_ui, cf_level):
             pfp_compliance.check_l2_options(cf_l2, ds1)
             if ds1.info["returncodes"]["value"] != 0:
                 return
-            ds2 = pfp_levels.l2qc(cf_l2, ds1)
-            outfilename = pfp_io.get_outfilenamefromcf(cf_l2)
-            pfp_io.NetCDFWrite(outfilename, ds2)
-            msg = "Finished L2 processing with " + cf_file_name[1]
-            logger.info(msg)
-            if "Plots" in list(cf_l2.keys()):
-                logger.info("Plotting L1 and L2 data")
-                for nFig in list(cf_l2['Plots'].keys()):
-                    if "(disabled)" in nFig:
-                        continue
-                    plt_cf = cf_l2['Plots'][str(nFig)]
-                    if 'type' in plt_cf.keys():
-                        if str(plt_cf['type']).lower() == 'xy':
-                            pfp_plot.plotxy(cf_l2, nFig, plt_cf, ds1, ds2)
+            if pfp_compliance.check_l2_controlfile(cf_l2):
+                ds2 = pfp_levels.l2qc(cf_l2, ds1)
+                outfilename = pfp_io.get_outfilenamefromcf(cf_l2)
+                pfp_io.NetCDFWrite(outfilename, ds2)
+                msg = "Finished L2 processing with " + cf_file_name[1]
+                logger.info(msg)
+                if "Plots" in list(cf_l2.keys()):
+                    logger.info("Plotting L1 and L2 data")
+                    for nFig in list(cf_l2['Plots'].keys()):
+                        if "(disabled)" in nFig:
+                            continue
+                        plt_cf = cf_l2['Plots'][str(nFig)]
+                        if 'type' in plt_cf.keys():
+                            if str(plt_cf['type']).lower() == 'xy':
+                                pfp_plot.plotxy(cf_l2, nFig, plt_cf, ds1, ds2)
+                            else:
+                                pfp_plot.plottimeseries(cf_l2, nFig, ds1, ds2)
                         else:
                             pfp_plot.plottimeseries(cf_l2, nFig, ds1, ds2)
-                    else:
-                        pfp_plot.plottimeseries(cf_l2, nFig, ds1, ds2)
-                logger.info("Finished plotting L1 and L2 data")
-            logger.info("")
+                    logger.info("Finished plotting L1 and L2 data")
+                logger.info("")
+            else:
+                msg = "Error occurred checking compliance of L2 controlfile"
+                logger.error(msg)
         except Exception:
             msg = "Error occurred during L2 processing " + cf_file_name[1]
             logger.error(msg)
@@ -475,17 +483,22 @@ def do_L5_batch(main_ui, cf_level):
             cf_l5["Options"]["show_plots"] = "No"
             infilename = pfp_io.get_infilenamefromcf(cf_l5)
             ds4 = pfp_io.NetCDFRead(infilename)
-            if ds4.info["returncodes"]["value"] != 0: return
-            ds5 = pfp_levels.l5qc(None, cf_l5, ds4)
-            outfilename = pfp_io.get_outfilenamefromcf(cf_l5)
-            pfp_io.NetCDFWrite(outfilename, ds5)
-            msg = "Finished L5 processing with " + cf_file_name[1]
-            logger.info(msg)
-            # do the CF compliance check
-            #do_batch_cfcheck(cf_l5)
-            # plot the L5 fingerprints
-            do_batch_fingerprints(cf_l5)
-            logger.info("")
+            if ds4.info["returncodes"]["value"] != 0:
+                return
+            if pfp_compliance.check_l5_controlfile(cf_l5):
+                ds5 = pfp_levels.l5qc(None, cf_l5, ds4)
+                outfilename = pfp_io.get_outfilenamefromcf(cf_l5)
+                pfp_io.NetCDFWrite(outfilename, ds5)
+                msg = "Finished L5 processing with " + cf_file_name[1]
+                logger.info(msg)
+                # do the CF compliance check
+                #do_batch_cfcheck(cf_l5)
+                # plot the L5 fingerprints
+                do_batch_fingerprints(cf_l5)
+                logger.info("")
+            else:
+                msg = "Error occurred checking compliance of L5 controlfile"
+                logger.error(msg)
         except Exception:
             msg = "Error occurred during L5 with " + cf_file_name[1]
             logger.error(msg)
@@ -514,15 +527,20 @@ def do_L6_batch(main_ui, cf_level):
             cf_l6["Options"]["show_plots"] = "No"
             infilename = pfp_io.get_infilenamefromcf(cf_l6)
             ds5 = pfp_io.NetCDFRead(infilename)
-            if ds5.info["returncodes"]["value"] != 0: return
-            ds6 = pfp_levels.l6qc(None, cf_l6, ds5)
-            outfilename = pfp_io.get_outfilenamefromcf(cf_l6)
-            pfp_io.NetCDFWrite(outfilename, ds6)
-            msg = "Finished L6 processing with " + cf_file_name[1]
-            logger.info(msg)
-            # do the CF compliance check
-            #do_batch_cfcheck(cf_l6)
-            logger.info("")
+            if ds5.info["returncodes"]["value"] != 0:
+                return
+            if pfp_compliance.check_l6_controlfile(cf_l6):
+                ds6 = pfp_levels.l6qc(None, cf_l6, ds5)
+                outfilename = pfp_io.get_outfilenamefromcf(cf_l6)
+                pfp_io.NetCDFWrite(outfilename, ds6)
+                msg = "Finished L6 processing with " + cf_file_name[1]
+                logger.info(msg)
+                # do the CF compliance check
+                #do_batch_cfcheck(cf_l6)
+                logger.info("")
+            else:
+                msg = "Error occurred checking compliance of L6 controlfile"
+                logger.error(msg)
         except Exception:
             msg = "Error occurred during L6 with " + cf_file_name[1]
             logger.error(msg)

--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -733,12 +733,15 @@ def do_IRGAcheck(cf,ds):
         msg = " *** IRGA_Check disbled in control file"
         logger.warning(msg)
         return
-    # get the IRGA type from the control file
-    irga_type = pfp_utils.get_keyvaluefromcf(cf, ["Options"], "irga_type", default="not found")
-    if irga_type == "not found":
-        msg = " IRGA type not specified in Options section, using default (Li-7500)"
-        logger.warning(msg)
-        irga_type = "Li-7500"
+    # get the IRGA type from the global attributes or the control file
+    if "irga_type" in ds.root["Attributes"]:
+        irga_type = str(ds.root["Attributes"])
+    else:
+        irga_type = pfp_utils.get_keyvaluefromcf(cf, ["Options"], "irga_type", default="not found")
+        if irga_type == "not found":
+            msg = " IRGA type not in global attributes or Options section, using Li-7500"
+            logger.warning(msg)
+            irga_type = "Li-7500"
     # do the IRGA checks
     if irga_type in ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)"]:
         ds.root["Attributes"]["irga_type"] = irga_type
@@ -750,7 +753,7 @@ def do_IRGAcheck(cf,ds):
         ds.root["Attributes"]["irga_type"] = irga_type
         do_EC155check(cf, ds)
     else:
-        msg = " Unsupported IRGA type " + irga_type + ", contact the devloper ..."
+        msg = " Unsupported IRGA type " + irga_type + ", contact the developer ..."
         logger.error(msg)
         return
     return

--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -735,7 +735,7 @@ def do_IRGAcheck(cf,ds):
         return
     # get the IRGA type from the global attributes or the control file
     if "irga_type" in ds.root["Attributes"]:
-        irga_type = str(ds.root["Attributes"])
+        irga_type = str(ds.root["Attributes"]["irga_type"])
     else:
         irga_type = pfp_utils.get_keyvaluefromcf(cf, ["Options"], "irga_type", default="not found")
         if irga_type == "not found":

--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -513,7 +513,8 @@ def do_EC155check(cf, ds, code=4):
     Author: PRI
     Date: October 2020 (rewrite of original)
     """
-    msg = " Doing the IRGA (EC150/155) check"
+    irga_type = str(ds.root["Attributes"]["irga_type"])
+    msg = " Doing the IRGA (" + irga_type + ") check"
     logger.info(msg)
     nrecs = int(ds.root["Attributes"]["nc_nrecs"])
     labels = list(ds.root["Variables"].keys())

--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -722,8 +722,8 @@ def do_IRGAcheck(cf,ds):
     """
     Purpose:
      Decide which IRGA check routine to use depending on the setting
-     of the "irga_type" key in the [Options] section of the control
-     file.  The default is Li7500.
+     of the "irga_type" key in the global attributes or the [Options]
+     section of the control file.  The default is Li-7500.
     Usage:
     Author: PRI
     Date: September 2015
@@ -755,117 +755,6 @@ def do_IRGAcheck(cf,ds):
         logger.error(msg)
         return
     return
-
-#def do_li7500check(cf, ds, code=4):
-    #"""
-    #Purpose:
-     #Reject covariances of H2O (UxA, UyA and UzA) and CO2 (UzC, UyC and UzC)
-     #based on the IRGA AGC and the standard deviation or variance of H2O and
-     #CO2 concentration.
-     #QC checks on AGC and standard deviation or variance of H2O and CO2 are
-     #performed before this routine is called.  This routine then rejects the
-     #covariance values for those times when the precursors have been rejected.
-     #Only 1 H2O and 1 CO2 variable, either standard deviation or
-     #variance, are used.
-     #This routine is an implicit DependencyCheck.
-     #Li-7500 version.
-    #Usage:
-     #pfp_ch.do_li7500check(cf, ds, code=4)
-     #where cf is a control file
-           #ds is a data structure
-    #Side effects:
-     #Covariance values are masked and flags set to 4 for all time steps when
-     #any of the precursors have failed a previous QC check.
-    #Author: PRI
-    #Date: October 2020 (rewrite of original)
-    #"""
-    #msg = " Doing the IRGA (Li-7500) check"
-    #logger.info(msg)
-    #nrecs = int(ds.root["Attributes"]["nc_nrecs"])
-    #labels = list(ds.root["Variables"].keys())
-    ## list of variables to be modified by this QC check
-    #dependents = ["UzA", "UxA", "UyA", "UzC", "UxC", "UyC",
-                  #"AH_IRGA_Av", "AH_IRGA_Sd", "AH_IRGA_Vr",
-                  #"CO2_IRGA_Av", "CO2_IRGA_Sd", "CO2_IRGA_Vr",
-                  #"H2O_IRGA_Av", "H2O_IRGA_Sd", "H2O_IRGA_Vr"]
-    ## check these are in the data structure
-    #for label in list(dependents):
-        #if label not in labels:
-            #dependents.remove(label)
-    ## return if there are no dependents to check
-    #if len(dependents) == 0:
-        #msg = "  No dependent variables found, skipping IRGA check ..."
-        #logger.info(msg)
-        #return
-    ## list for conditional variables
-    #conditionals = []
-    ## check if we have the IRGA diagnostic
-    #got_diag = False
-    #for diag in ["Diag_IRGA", "Diag_7500"]:
-        #if diag in labels:
-            #got_diag = True
-            #conditionals.append(diag)
-            #break
-    #if not got_diag:
-        #msg = " IRGA diagnostic (Diag_IRGA) not found in data"
-        #logger.warning(msg)
-    ## check if we have an AGC (only use one)
-    #got_AGC = False
-    #for agc in ["AGC_7500", "AGC_IRGA"]:
-        #if agc in labels:
-            #got_AGC = True
-            #conditionals.append(agc)
-            #break
-    #if not got_AGC:
-        #msg = " AGC not used in IRGA check (not in data structure)"
-        #logger.warning(msg)
-    ## check of H2O standard deviation or variance (only use one)
-    #got_H2O = False
-    #for h2o in ["H2O_IRGA_Sd", "AH_IRGA_Sd", "H2O_IRGA_Vr", "AH_IRGA_Vr"]:
-        #if h2o in labels:
-            #got_H2O = True
-            #conditionals.append(h2o)
-            #break
-    #if not got_H2O:
-        #msg = " H2O standard deviation or variance not used in IRGA check (not in data structure)"
-        #logger.warning(msg)
-    ## check of CO2 standard deviation or variance (only use one)
-    #got_CO2 = False
-    #for co2 in ["CO2_IRGA_Sd", "CO2_IRGA_Vr"]:
-        #if co2 in labels:
-            #got_CO2 = True
-            #conditionals.append(co2)
-            #break
-    #if not got_CO2:
-        #msg = " CO2 standard deviation or variance not used in IRGA check (not in data structure)"
-        #logger.warning(msg)
-    ## return if we found no conditionals
-    #if len(conditionals) == 0:
-        #msg = " No conditional variables found, skipping IRGA check ..."
-        #logger.warning(msg)
-        #return
-    ## create an index series, 0 ==> not OK, 1 ==> OK
-    #cidx = numpy.ones(nrecs, dtype=int)
-    #for conditional in conditionals:
-        #variable = pfp_utils.GetVariable(ds, conditional)
-        #idx = numpy.where(numpy.ma.getmaskarray(variable["Data"]) == True)[0]
-        #msg = "  IRGA check: " + conditional + " rejected " + str(numpy.size(idx)) + " points"
-        #logger.info(msg)
-        #cidx[idx] = int(0)
-    #rejected = numpy.count_nonzero(cidx == 0)
-    #percent = int(numpy.rint(100*rejected/nrecs))
-    #msg = "  IRGA check: total number of points rejected was " + str(rejected)
-    #msg += " (" + str(percent) + "%)"
-    #logger.info(msg)
-    ## use the conditional series to mask the dependents
-    #for dependent in dependents:
-        #variable = pfp_utils.GetVariable(ds, dependent)
-        #variable["Data"] = numpy.ma.masked_where(cidx == int(0), variable["Data"])
-        #idx = numpy.where(cidx == int(0))[0]
-        #variable["Flag"][idx] = int(code)
-        #variable["Attr"]["irga_check"] = ",".join(dependents)
-        #pfp_utils.CreateVariable(ds, variable)
-    #return
 
 def do_li7500check(cf, ds, code=4):
     """

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -1142,9 +1142,10 @@ def display_messages_interactive(messages, mode="Close"):
             logger.error(item)
             error_messages.append(item)
         logger.error("!!!!!")
-    for item in messages["WARNING"]:
+    if len(messages["WARNING"]) > 0:
         logger.warning("?????")
-        logger.warning(item)
+        for item in messages["WARNING"]:
+            logger.warning(item)
         logger.warning("?????")
     for item in messages["INFO"]:
         logger.info(item)

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -1008,7 +1008,12 @@ def check_l6_controlfile(cfg):
     l6_check_ecosystemrespiration(cfg, messages)
     l6_check_netecosystemexchange(cfg, messages)
     l6_check_grossprimaryproductivity(cfg, messages)
-    display_messages_interactive(messages)
+    # check if we are running in interactive mode and display messages accordingly
+    opt = pfp_utils.get_keyvaluefromcf(cfg, ["Options"], "call_mode", default="interactive")
+    if opt.lower() == "interactive":
+        display_messages_interactive(messages)
+    else:
+        display_messages_batch(messages)
     if len(messages["ERROR"]) > 0:
         ok = False
     return ok

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -908,7 +908,7 @@ def check_l3_options(cfg, ds):
     check_l3_options_rotation(cfg, ds, messages)
     opt = pfp_utils.get_keyvaluefromcf(cfg, ["Options"], "call_mode", default="interactive")
     if opt.lower() == "interactive":
-        display_messages_interactive(messages)
+        display_messages_interactive(messages, mode="CloseOrIgnore")
         if messages["RESULT"] == "ignore":
             ds.info["returncodes"]["value"] = 0
         else:
@@ -1123,7 +1123,7 @@ def display_messages_batch(messages):
             else:
                 raise RuntimeError("display_messages_batch: Unrecognised message in messages")
     return
-def display_messages_interactive(messages):
+def display_messages_interactive(messages, mode="Close"):
     # gather variable error messages into a single list
     error_messages = []
     if len(messages["ERROR"]) > 0:
@@ -1144,8 +1144,16 @@ def display_messages_interactive(messages):
         msg += error_messages[-1] + "\n\n"
         msg += "Fix the errors, close this window and run again."
         # put up the message box
-        msgbox = pfp_gui.MsgBox_CloseOrIgnore(msg, title="Errors")
-        messages["RESULT"] = msgbox.execute()
+        if mode == "Close":
+            msgbox = pfp_gui.MsgBox_Close(msg, title="Errors")
+            messages["RESULT"] = msgbox.execute()
+        elif mode == "CloseOrIgnore":
+            msgbox = pfp_gui.MsgBox_CloseOrIgnore(msg, title="Errors")
+            messages["RESULT"] = msgbox.execute()
+        else:
+            msg = "Unrecognised mode in display_messages_interactive()"
+            logger.error(msg)
+            messages["RESULT"] = "close"
     return
 def l1_check_files(cfg, std, messages):
     # check the Files section exists

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -722,6 +722,59 @@ def check_l1_controlfile(cfg):
                 l1_check_variables_sections(cfg, std, cfg_label, std_label, messages)
                 # append this variable name to the done list
                 done.append(cfg_label)
+        # check IRGA instrument type
+        l1_check_irga_type(cfg, messages)
+        # display and messages
+        display_messages(messages)
+        if len(messages["ERROR"]) > 0:
+            ok = False
+    except Exception:
+        ok = False
+        error_message = " Error checking L1 control file, see below for details ... "
+        logger.error(error_message)
+        error_message = traceback.format_exc()
+        logger.error(error_message)
+    return ok
+def check_l2_controlfile(cfg):
+    """
+    Purpose:
+     Check the L2 control file to make sure it contains all information
+     needed to run L2 and that all information is correct.
+    Usage:
+    Side effects:
+    Author: PRI
+    Date: October 2022
+    """
+    # quick and dirty use of try...except in a panic ahead to 2021 workshop
+    try:
+        ok = True
+        # initialise the messages dictionary
+        messages = {"ERROR":[], "WARNING": [], "INFO": []}
+        # check the files section
+        l2_check_files(cfg, messages)
+        # check the options section
+        l2_check_options(cfg, messages)
+        # check the variables section
+        #l2_check_variables_section(cfg, std, messages)
+        ## check variables whose name exactly matches an entry in the settings/l1.txt control file
+        #done = []
+        #label_matches = [l for l in cfg_labels if l in std_labels]
+        #for cfg_label in label_matches:
+            #std_label = cfg_label
+            ## check variable 'Attr' section
+            #l1_check_variables_sections(cfg, std, cfg_label, std_label, messages)
+            ## append this variable name to the done list
+            #done.append(cfg_label)
+        ## check variables where the first characters of the name match an entry in settings/l1.txt
+        #cfg_labels = sorted(list(cfg["Variables"].keys()))
+        #for std_label in std_labels:
+            #lsl = len(std_label)
+            #label_matches = [l for l in cfg_labels if l[:min([len(l),lsl])] == std_label and l not in done]
+            #for cfg_label in label_matches:
+                ## check variable 'Attr' section
+                #l1_check_variables_sections(cfg, std, cfg_label, std_label, messages)
+                ## append this variable name to the done list
+                #done.append(cfg_label)
         display_messages(messages)
         if len(messages["ERROR"]) > 0:
             ok = False
@@ -1119,6 +1172,54 @@ def l1_check_variables_sections(cfg, std, cfg_label, std_label, messages):
                         pass
         else:
             msg = cfg_label + ": 'func' not found in 'Function' subsection"
+            messages["ERROR"].append(msg)
+    return
+def l1_check_irga_type(cfg, messages):
+    known_irgas = ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)",
+                   "Li-7500A (>=V6.5)", "Li-7500RS", "Li-7200", "Li-7200RS",
+                   "EC150", "EC155", "IRGASON"]
+    signal_labels = ["Signal_CO2", "Signal_H2O"]
+    h2o_covars = ["UxA", "UyA", "UzA"]
+    co2_covars = ["UxC", "UyC", "UzC"]
+    cfg_labels = sorted(list(cfg["Variables"].keys()))
+    irga_labels = [l for l in cfg_labels if "IRGA" in l]
+    irga_labels = irga_labels + signal_labels + h2o_covars + co2_covars
+    for irga_label in list(irga_labels):
+        if irga_label not in cfg_labels:
+            irga_labels.remove(irga_label)
+    irga_check = {}
+    for irga_label in irga_labels:
+        ok = False
+        if "instrument" in cfg["Variables"][irga_label]["Attr"]:
+            irga_type = cfg["Variables"][irga_label]["Attr"]["instrument"]
+            if irga_type in known_irgas:
+                ok = True
+                if irga_type not in irga_check:
+                    irga_check[irga_type] = []
+                irga_check[irga_type].append(irga_label)
+            else:
+                for known_irga in known_irgas:
+                    if known_irga in irga_type:
+                        ok = True
+                        if known_irga not in irga_check:
+                            irga_check[known_irga] = []
+                        irga_check[known_irga].append(irga_label)
+            if not ok:
+                msg = "Unknown IRGA type (" + irga_type + ") for " + irga_label
+                messages["ERROR"].append(msg)
+        else:
+            msg = "'instrument' attribute missing for " + irga_label
+            messages["ERROR"].append(msg)
+    irga_types = list(irga_check.keys())
+    if len(irga_types) == 1:
+        cfg["Global"]["irga_type"] = str(irga_types[0])
+        msg = "IRGA type set to " + cfg["Global"]["irga_type"]
+        logger.info(msg)
+    else:
+        msg = "More than 1 IRGA type specified (" + ",".join(irga_types) + ")"
+        messages["ERROR"].append(msg)
+        for irga_type in irga_types:
+            msg = irga_type + " is used for " + ",".join(irga_check[irga_type])
             messages["ERROR"].append(msg)
     return
 def l1_check_variables_height(cfg, cfg_label, messages):
@@ -1585,6 +1686,85 @@ def update_cfg_variables_deprecated(cfg, std):
             cfg[section_name].pop(label)
     return cfg
 
+def l2_check_files(cfg, messages):
+    # check the Files section exists
+    if ("Files" in cfg):
+        # check file_path is in the Files section
+        if "file_path" in cfg["Files"]:
+            file_path = cfg["Files"]["file_path"]
+            # check file_path directory exists
+            if os.path.isdir(file_path):
+                pass
+            else:
+                msg = "Files: " + file_path + " is not a directory"
+                messages["ERROR"].append(msg)
+        else:
+            msg = "Files: 'file_path' not in section"
+            messages["ERROR"].append(msg)
+        # check plot_path is in the Files section
+        if "plot_path" in cfg["Files"]:
+            plot_path = cfg["Files"]["plot_path"]
+            # check plot_path directory exists
+            if os.path.isdir(plot_path):
+                pass
+            else:
+                msg = "Files: " + plot_path + " is not a directory"
+                messages["ERROR"].append(msg)
+        else:
+            msg = "Files: 'plot_path' not in section"
+            messages["ERROR"].append(msg)
+        # check in_filename is in the Files section
+        if "in_filename" in cfg["Files"]:
+            file_name = cfg["Files"]["in_filename"]
+            file_parts = os.path.splitext(file_name)
+            # check the file type is supported
+            if (file_parts[-1].lower() in  [".nc"]):
+                file_uri = os.path.join(file_path, file_name)
+                if os.path.isfile(file_uri):
+                    pass
+                else:
+                    msg = "Files: " + file_name + " not found"
+                    messages["ERROR"].append(msg)
+            else:
+                msg = "Files: " + file_name + " doesn't end with .nc"
+                messages["ERROR"].append(msg)
+        else:
+            msg = "Files: 'in_filename' not in section"
+            messages["ERROR"].append(msg)
+        # check the output file type
+        if "out_filename" in cfg["Files"]:
+            file_name = cfg["Files"]["out_filename"]
+            file_parts = os.path.splitext(file_name)
+            if (file_parts[-1].lower() in [".nc"]):
+                pass
+            else:
+                msg = "Files: " + file_name + " doesn't end with .nc"
+                messages["ERROR"].append(msg)
+        else:
+            msg = "Files: 'out_filename' not in section"
+            messages["ERROR"].append(msg)
+    else:
+        msg = "'Files' section not in control file"
+        messages["ERROR"].append(msg)
+    return
+def l2_check_options(cfg, messages):
+    """ Check the Options section in the L2 control file."""
+    if "Options" in cfg:
+        if "irga_type" in cfg["Options"]:
+            irga_type = str(cfg["Options"]["irga_type"])
+            if irga_type in ["Li-7500", "Li-7500A (<V6.5)", "Li-7500A (>=V6.5)", "Li-7500RS",
+                             "Li-7200", "Li-7200RS", "EC150", "EC155", "IRGASON"]:
+                pass
+            else:
+                msg = "Unrecognised IRGA type"
+                messages["ERROR"].append(msg)
+        else:
+            msg = "irga_type not found in Options section"
+            messages["ERROR"].append(msg)
+    else:
+        msg = "No Options section in control file (required to specify irga_type)"
+        messages["ERROR"].append(msg)
+    return
 def l2_update_controlfile(cfg):
     """
     Purpose:

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -10,6 +10,7 @@ from configobj import ConfigObj
 #import numpy
 import timezonefinder
 # PFP modules
+from scripts import constants as c
 from scripts import pfp_func_units
 from scripts import pfp_func_stats
 from scripts import pfp_gui
@@ -802,8 +803,8 @@ def check_l2_options(cfg, ds):
     Date: October 2022
     """
     messages = {"ERROR":[], "WARNING": [], "INFO": []}
-    closed_path_irgas = ["Li-7200", "Li-7200RS", "EC155"]
-    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500RS", "EC150", "IRGASON"]
+    closed_path_irgas = list(c.instruments["irgas"]["closed_path"].keys())
+    open_path_irgas = list(c.instruments["irgas"]["open_path"].keys())
     irga_types = open_path_irgas + closed_path_irgas
     nc_irga_type = None
     cfg_irga_type = None
@@ -902,7 +903,7 @@ def check_l3_options(cfg, ds):
     Author: PRI
     Date: October 2022
     """
-    messages = {"ERROR":[], "WARNING": [], "INFO": [], "RESULT": "close"}
+    messages = {"ERROR":[], "WARNING": [], "INFO": [], "RESULT": "ignore"}
     check_l3_options_wpl(cfg, ds, messages)
     check_l3_options_rotation(cfg, ds, messages)
     opt = pfp_utils.get_keyvaluefromcf(cfg, ["Options"], "call_mode", default="interactive")
@@ -946,8 +947,8 @@ def check_l3_options_wpl(cfg, ds, messages):
     if calculate_fluxes_option.lower() == "no":
         return
     # define the known IRGAs, this should be an external settings option
-    closed_path_irgas = ["Li-7200", "Li-7200RS", "EC155"]
-    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500RS", "EC150", "IRGASON"]
+    closed_path_irgas = list(c.instruments["irgas"]["closed_path"].keys())
+    open_path_irgas = list(c.instruments["irgas"]["open_path"].keys())
     # get the IRGA type from the global attributes
     irga_type = str(ds.root["Attributes"]["irga_type"])
     # get the ApplyWPL setting from the L3 [Options] section
@@ -1399,8 +1400,9 @@ def l1_check_input_labels(cfg, messages):
             messages["WARNING"].append(msg)
     return
 def l1_check_irga_type(cfg, messages):
-    known_irgas = ["Li-7500", "Li-7500A", "Li-7500RS", "Li-7200", "Li-7200RS",
-                   "EC150", "EC155", "IRGASON"]
+    open_path_irgas = list(c.instruments["irgas"]["open_path"].keys())
+    closed_path_irgas = list(c.instruments["irgas"]["closed_path"].keys())
+    known_irgas = open_path_irgas + closed_path_irgas
     signal_labels = ["Signal_CO2", "Signal_H2O"]
     # PFP covariances
     h2o_covars = ["UxA", "UyA", "UzA"]
@@ -1464,7 +1466,7 @@ def l1_check_sonic_type(cfg, messages):
     Author: PRI
     Date: November 2022
     """
-    known_sonics = ["CSAT3", "CSAT3B"]
+    known_sonics = list(c.instruments["sonics"].keys())
     # PFP covariances
     sonic_covars = ["UxT", "UyT", "UzT", "UxUy", "UxUz", "UyUz"]
     cfg_labels = sorted(list(cfg["Variables"].keys()))

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -845,7 +845,7 @@ def check_l2_options(cfg, ds):
             ds.info["returncodes"]["value"] = 1
             messages["ERROR"].append(msg)
     # check the sonic type
-    sonic_types = ["CSAT3", "CSAT3B"]
+    sonic_types = list(c.instruments["sonics"].keys())
     nc_sonic_type = None
     cfg_sonic_type = None
     # is sonic_type in the global attributes?

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -801,8 +801,7 @@ def check_l2_options(cfg, ds):
     """
     messages = {"ERROR":[], "WARNING": [], "INFO": []}
     closed_path_irgas = ["Li-7200", "Li-7200RS", "EC155"]
-    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)", "Li-7500A (>=V6.5)", "Li-7500RS",
-                       "EC150", "IRGASON"]
+    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500RS", "EC150", "IRGASON"]
     irga_types = open_path_irgas + closed_path_irgas
     nc_irga_type = None
     cfg_irga_type = None
@@ -860,8 +859,7 @@ def check_l3_options(cfg, ds):
     """
     messages = {"ERROR":[], "WARNING": [], "INFO": []}
     closed_path_irgas = ["Li-7200", "Li-7200RS", "EC155"]
-    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)", "Li-7500A (>=V6.5)", "Li-7500RS",
-                       "EC150", "IRGASON"]
+    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500RS", "EC150", "IRGASON"]
     irga_type = str(ds.root["Attributes"]["irga_type"])
     opt = pfp_utils.get_keyvaluefromcf(cfg, ["Options"], "ApplyWPL", default="Yes")
     if ((opt.lower() == "yes" and irga_type in open_path_irgas) or
@@ -1308,8 +1306,7 @@ def l1_check_input_labels(cfg, messages):
             messages["WARNING"].append(msg)
     return
 def l1_check_irga_type(cfg, messages):
-    known_irgas = ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)",
-                   "Li-7500A (>=V6.5)", "Li-7500RS", "Li-7200", "Li-7200RS",
+    known_irgas = ["Li-7500", "Li-7500A", "Li-7500RS", "Li-7200", "Li-7200RS",
                    "EC150", "EC155", "IRGASON"]
     signal_labels = ["Signal_CO2", "Signal_H2O"]
     h2o_covars = ["UxA", "UyA", "UzA"]

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -1123,6 +1123,8 @@ def display_messages_batch(messages):
                 logger.warning(msg)
             elif msg_type == "INFO":
                 logger.info(msg)
+            elif msg_type == "RESULT":
+                pass
             else:
                 raise RuntimeError("display_messages_batch: Unrecognised message in messages")
     return

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -722,6 +722,10 @@ def check_l1_controlfile(cfg):
                 l1_check_variables_sections(cfg, std, cfg_label, std_label, messages)
                 # append this variable name to the done list
                 done.append(cfg_label)
+        # check for duplicate netCDF variable labels
+        l1_check_nc_labels(cfg, messages)
+        # check for duplicate input variable labels
+        l1_check_input_labels(cfg, messages)
         # check IRGA instrument type
         l1_check_irga_type(cfg, messages)
         # display and messages
@@ -1287,6 +1291,26 @@ def l1_check_variables_sections(cfg, std, cfg_label, std_label, messages):
             msg = cfg_label + ": 'func' not found in 'Function' subsection"
             messages["ERROR"].append(msg)
     return
+def l1_check_input_labels(cfg, messages):
+    # check for duplicate input labels
+    file_parts = os.path.splitext(cfg["Files"]["in_filename"])
+    if ("xls" in file_parts[-1].lower()):
+        source = "xl"
+    elif ("csv" in file_parts[-1].lower()):
+        source = "csv"
+    else:
+        msg = "Unexpected input source (" + file_parts[-1].lower() + ")"
+        raise RuntimeError(msg)
+    input_labels = [cfg["Variables"][l][source]["name"] for l in cfg["Variables"]]
+    duplicate_labels = [l for l in set(input_labels) if input_labels.count(l) > 1]
+    if len(duplicate_labels) > 0:
+        for duplicate_label in duplicate_labels:
+            nc_duplicate_labels = [l for l in cfg["Variables"]
+                                   if cfg["Variables"][l][source]["name"]==duplicate_label]
+            msg = "Duplicate input label " + duplicate_label + " used for "
+            msg += ",".join(nc_duplicate_labels)
+            messages["WARNING"].append(msg)
+    return
 def l1_check_irga_type(cfg, messages):
     known_irgas = ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)",
                    "Li-7500A (>=V6.5)", "Li-7500RS", "Li-7200", "Li-7200RS",
@@ -1334,6 +1358,16 @@ def l1_check_irga_type(cfg, messages):
         for irga_type in irga_types:
             msg = irga_type + " is used for " + ",".join(irga_check[irga_type])
             messages["ERROR"].append(msg)
+    return
+def l1_check_nc_labels(cfg, messages):
+    nc_labels = list(cfg["Variables"].keys())
+    duplicate_labels = [l for l in set(nc_labels) if nc_labels.count(l) > 1]
+    if len(duplicate_labels) == 0:
+        return
+    for duplicate_label in duplicate_labels:
+        msg = "Duplicate netCDF label " + duplicate_label + " found "
+        msg += str(duplicate_labels.count(duplicate_label)) + " times"
+        messages["ERROR"].append(msg)
     return
 def l1_check_variables_height(cfg, cfg_label, messages):
     cfg_attr = cfg["Variables"][cfg_label]["Attr"]

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -885,7 +885,7 @@ def check_l2_options(cfg, ds):
             msg += ") and L2 control file ("+cfg_sonic_type+")"
             ds.info["returncodes"]["value"] = 1
             messages["ERROR"].append(msg)
-
+    # check if we are running in interactive mode and display messages accordingly
     opt = pfp_utils.get_keyvaluefromcf(cfg, ["Options"], "call_mode", default="interactive")
     if opt.lower() == "interactive":
         display_messages_interactive(messages)

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -725,7 +725,7 @@ def check_l1_controlfile(cfg):
         # check IRGA instrument type
         l1_check_irga_type(cfg, messages)
         # display and messages
-        display_messages(messages)
+        display_messages_interactive(messages)
         if len(messages["ERROR"]) > 0:
             ok = False
     except Exception:
@@ -775,7 +775,7 @@ def check_l2_controlfile(cfg):
                 #l1_check_variables_sections(cfg, std, cfg_label, std_label, messages)
                 ## append this variable name to the done list
                 #done.append(cfg_label)
-        display_messages(messages)
+        display_messages_interactive(messages)
         if len(messages["ERROR"]) > 0:
             ok = False
     except Exception:
@@ -785,6 +785,94 @@ def check_l2_controlfile(cfg):
         error_message = traceback.format_exc()
         logger.error(error_message)
     return ok
+def check_l2_options(cfg, ds):
+    """
+    Purpose:
+     Check the options specified in the L3 control file are consistent
+     with the contents of the L2 netCDF file.
+    Usage:
+    Side effects:
+    Author: PRI
+    Date: October 2022
+    """
+    messages = {"ERROR":[], "WARNING": [], "INFO": []}
+    closed_path_irgas = ["Li-7200", "Li-7200RS", "EC155"]
+    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)", "Li-7500A (>=V6.5)", "Li-7500RS",
+                       "EC150", "IRGASON"]
+    irga_types = open_path_irgas + closed_path_irgas
+    nc_irga_type = None
+    cfg_irga_type = None
+    if ("irga_type" in ds.root["Attributes"]):
+        nc_irga_type = str(ds.root["Attributes"]["irga_type"])
+    if ("irga_type" in cfg["Options"]):
+        cfg_irga_type = str(cfg["Options"]["irga_type"])
+    if ((nc_irga_type is None) and (cfg_irga_type is None)):
+        # IRGA type not found in the L1 netCDF file or the control file
+        msg = "IRGA type not specified in L1 netCDF file or L2 control file"
+        messages["ERROR"].append(msg)
+        ds.info["returncodes"]["value"] = 1
+    elif ((nc_irga_type is None) and (cfg_irga_type is not None)):
+        # IRGA type not found in the L1 netCDF file but found in the L2 control file
+        if (cfg_irga_type not in irga_types):
+            # make sure the IRGA type is in the known IRGA list
+            msg = "Unknown IRGA type specified in control file (" + cfg_irga_type + ")"
+            messages["ERROR"].append(msg)
+            ds.info["returncodes"]["value"] = 1
+        else:
+            ds.root["Attributes"]["irga_type"] = cfg_irga_type
+    elif ((nc_irga_type is not None) and (cfg_irga_type is None)):
+        # IRGA type found in the L1 netCDF file but not found in the L2 control file
+        if (nc_irga_type not in irga_types):
+            # make sure the IRGA type is in the known IRGA list
+            msg = "Unknown IRGA type specified in netCDF file (" + nc_irga_type + ")"
+            messages["ERROR"].append(msg)
+            ds.info["returncodes"]["value"] = 1
+        else:
+            pass
+    else:
+        # IRGA type found in the L1 netCDF file and the L2 control file
+        if (nc_irga_type == cfg_irga_type):
+            pass
+        else:
+            msg = "Different IRGA types in L1 netCDF ("+nc_irga_type
+            msg += ") and L2 control file ("+cfg_irga_type+")"
+            ds.info["returncodes"]["value"] = 1
+            messages["ERROR"].append(msg)
+    opt = pfp_utils.get_keyvaluefromcf(cfg, ["Options"], "call_mode", default="interactive")
+    if opt.lower() == "interactive":
+        display_messages_interactive(messages)
+    else:
+        display_messages_batch(messages)
+    return
+def check_l3_options(cfg, ds):
+    """
+    Purpose:
+     Check the options specified in the L3 control file are consistent
+     with the contents of the L2 netCDF file.
+    Usage:
+    Side effects:
+    Author: PRI
+    Date: October 2022
+    """
+    messages = {"ERROR":[], "WARNING": [], "INFO": []}
+    closed_path_irgas = ["Li-7200", "Li-7200RS", "EC155"]
+    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)", "Li-7500A (>=V6.5)", "Li-7500RS",
+                       "EC150", "IRGASON"]
+    irga_type = str(ds.root["Attributes"]["irga_type"])
+    opt = pfp_utils.get_keyvaluefromcf(cfg, ["Options"], "ApplyWPL", default="Yes")
+    if ((opt.lower() == "yes" and irga_type in open_path_irgas) or
+        (opt.lower() == "no" and irga_type in closed_path_irgas)):
+        pass
+    else:
+        msg = "Wrong ApplyWPL option ("+opt+") for IRGA type ("+irga_type+")"
+        ds.info["returncodes"]["value"] = 1
+        messages["ERROR"].append(msg)
+    opt = pfp_utils.get_keyvaluefromcf(cfg, ["Options"], "call_mode", default="interactive")
+    if opt.lower() == "interactive":
+        display_messages_interactive(messages)
+    else:
+        display_messages_batch(messages)
+    return
 def check_l5_controlfile(cfg):
     """
     Purpose:
@@ -803,7 +891,7 @@ def check_l5_controlfile(cfg):
         if "cpd_filename" in cfg["Files"]:
             msg = "ustar_threshold section and Files/cpd_filename present"
             messages["ERROR"].append(msg)
-    display_messages(messages)
+    display_messages_interactive(messages)
     if len(messages["ERROR"]) > 0:
         ok = False
     return ok
@@ -825,7 +913,7 @@ def check_l6_controlfile(cfg):
     l6_check_ecosystemrespiration(cfg, messages)
     l6_check_netecosystemexchange(cfg, messages)
     l6_check_grossprimaryproductivity(cfg, messages)
-    display_messages(messages)
+    display_messages_interactive(messages)
     if len(messages["ERROR"]) > 0:
         ok = False
     return ok
@@ -845,7 +933,7 @@ def check_windrose_controlfile(cfg):
     check_windrose_files_section(cfg, messages)
     check_windrose_options_section(cfg, messages)
     check_windrose_variables_section(cfg, messages)
-    display_messages(messages)
+    display_messages_interactive(messages)
     if len(messages["ERROR"]) > 0:
         ok = False
     return ok
@@ -926,11 +1014,32 @@ def check_windrose_variables_section(cfg, messages):
             msg = item + " does not have required key 'name'"
             messages["ERROR"].append(msg)
     return
-def display_messages(messages):
+def display_messages_batch(messages):
+    for msg_type in list(messages.keys()):
+        if (len(messages[msg_type]) == 0):
+            continue
+        for msg in messages[msg_type]:
+            if msg_type == "ERROR":
+                logger.error("!!!!!")
+                logger.error(msg)
+                logger.error("!!!!!")
+                raise RuntimeError(msg)
+            elif msg_type == "WARNING":
+                logger.warning(msg)
+            elif msg_type == "INFO":
+                logger.info(msg)
+            else:
+                raise RuntimeError("display_messages_batch: Unrecognised message in messages")
+    return
+def display_messages_interactive(messages):
     # gather variable error messages into a single list
     error_messages = []
-    for item in messages["ERROR"]:
+    for n, item in enumerate(messages["ERROR"]):
+        if n == 0:
+            logger.error("!!!!!")
         logger.error(item)
+        if n == 0:
+            logger.error("!!!!!")
         error_messages.append(item)
     for item in messages["WARNING"]:
         logger.warning(item)
@@ -944,7 +1053,7 @@ def display_messages(messages):
         msg += error_messages[-1] + "\n\n"
         msg += "Fix the errors, close this window and run again."
         # put up the message box
-        pfp_gui.MsgBox_Quit(msg, title="Errors")
+        pfp_gui.MsgBox_Close(msg, title="Errors")
     return
 def l1_check_files(cfg, std, messages):
     # check the Files section exists
@@ -1754,20 +1863,10 @@ def l2_check_files(cfg, messages):
 def l2_check_options(cfg, messages):
     """ Check the Options section in the L2 control file."""
     if "Options" in cfg:
-        if "irga_type" in cfg["Options"]:
-            irga_type = str(cfg["Options"]["irga_type"])
-            if irga_type in ["Li-7500", "Li-7500A (<V6.5)", "Li-7500A (>=V6.5)", "Li-7500RS",
-                             "Li-7200", "Li-7200RS", "EC150", "EC155", "IRGASON"]:
-                pass
-            else:
-                msg = "Unrecognised IRGA type"
-                messages["ERROR"].append(msg)
-        else:
-            msg = "irga_type not found in Options section"
-            messages["ERROR"].append(msg)
+        pass
     else:
-        msg = "No Options section in control file (required to specify irga_type)"
-        messages["ERROR"].append(msg)
+        msg = "No Options section in control file, using defaults for all options"
+        messages["WARNING"].append(msg)
     return
 def l2_update_controlfile(cfg):
     """

--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -89,6 +89,7 @@ def  gfSOLO_gui(main_gui, ds, l5_info, called_by):
     # display the SOLO GUI
     main_gui.solo_gui.show()
     main_gui.solo_gui.exec_()
+    return
 
 def gfSOLO_autocomplete(ds, l5_info, called_by):
     """

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -1920,7 +1920,8 @@ class edit_cfg_L2(QtWidgets.QWidget):
     def add_options_section(self):
         """ Add an Options section."""
         self.sections["Options"] = QtGui.QStandardItem("Options")
-        new_options = {"irga_type": "Li-7500A"}
+        new_options = {"irga_type": "Li-7500RS", "sonic_type": "CSAT3B",
+                       "SONIC_Check": "Yes", "IRGA_Check": "Yes"}
         for key in new_options:
             value = new_options[key]
             child0 = QtGui.QStandardItem(key)

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -2204,16 +2204,11 @@ class edit_cfg_L2(QtWidgets.QWidget):
                         self.context_menu.actionSetIRGATypeLi7500.setText("Li-7500")
                         self.context_menu.addAction(self.context_menu.actionSetIRGATypeLi7500)
                         self.context_menu.actionSetIRGATypeLi7500.triggered.connect(self.set_irga_li7500)
-                    if existing_entry != "Li-7500A (<V6.5)":
-                        self.context_menu.actionSetIRGATypeLi7500APre6_5 = QtWidgets.QAction(self)
-                        self.context_menu.actionSetIRGATypeLi7500APre6_5.setText("Li-7500A (<V6.5)")
-                        self.context_menu.addAction(self.context_menu.actionSetIRGATypeLi7500APre6_5)
-                        self.context_menu.actionSetIRGATypeLi7500APre6_5.triggered.connect(self.set_irga_li7500a_pre6_5)
-                    if existing_entry != "Li-7500A (>=V6.5)":
-                        self.context_menu.actionSetIRGATypeLi7500APost6_5 = QtWidgets.QAction(self)
-                        self.context_menu.actionSetIRGATypeLi7500APost6_5.setText("Li-7500A (>=V6.5)")
-                        self.context_menu.addAction(self.context_menu.actionSetIRGATypeLi7500APost6_5)
-                        self.context_menu.actionSetIRGATypeLi7500APost6_5.triggered.connect(self.set_irga_li7500a_post6_5)
+                    if existing_entry != "Li-7500A":
+                        self.context_menu.actionSetIRGATypeLi7500A = QtWidgets.QAction(self)
+                        self.context_menu.actionSetIRGATypeLi7500A.setText("Li-7500A")
+                        self.context_menu.addAction(self.context_menu.actionSetIRGATypeLi7500A)
+                        self.context_menu.actionSetIRGATypeLi7500A.triggered.connect(self.set_irga_li7500a)
                     if existing_entry != "Li-7500RS":
                         self.context_menu.actionSetIRGATypeLi7500RS = QtWidgets.QAction(self)
                         self.context_menu.actionSetIRGATypeLi7500RS.setText("Li-7500RS")
@@ -2695,19 +2690,12 @@ class edit_cfg_L2(QtWidgets.QWidget):
         parent = selected_item.parent()
         parent.child(selected_item.row(), 1).setText("Li-7500")
 
-    def set_irga_li7500a_pre6_5(self):
-        """ Set the IRGA type to Li-7500A pre V6.5."""
+    def set_irga_li7500a(self):
+        """ Set the IRGA type to Li-7500A (pre and post V6.5)."""
         idx = self.view.selectedIndexes()[0]
         selected_item = idx.model().itemFromIndex(idx)
         parent = selected_item.parent()
-        parent.child(selected_item.row(), 1).setText("Li-7500A (<V6.5)")
-
-    def set_irga_li7500a_post6_5(self):
-        """ Set the IRGA type to Li-7500A post V6.5."""
-        idx = self.view.selectedIndexes()[0]
-        selected_item = idx.model().itemFromIndex(idx)
-        parent = selected_item.parent()
-        parent.child(selected_item.row(), 1).setText("Li-7500A (>=V6.5)")
+        parent.child(selected_item.row(), 1).setText("Li-7500A")
 
     def set_irga_li7500rs(self):
         """ Set the IRGA type to Li-7500RS."""

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -2870,6 +2870,14 @@ class edit_cfg_L3(QtWidgets.QWidget):
         self.add_qc_check(selected_item, new_qc)
         self.update_tab_text()
 
+    def add_DisableWPL_to_options(self):
+        """ Add DisableWPL to the [Options] section."""
+        child0 = QtGui.QStandardItem("DisableWPL")
+        child0.setEditable(False)
+        child1 = QtGui.QStandardItem("Yes")
+        self.sections["Options"].appendRow([child0, child1])
+        self.update_tab_text()
+
     def add_diurnalcheck(self):
         """ Add a diurnal check to a variable."""
         new_qc = {"DiurnalCheck":{"numsd":"5"}}
@@ -3355,6 +3363,11 @@ class edit_cfg_L3(QtWidgets.QWidget):
                     self.context_menu.actionAddFco2Units.setText("Fco2Units")
                     self.context_menu.addAction(self.context_menu.actionAddFco2Units)
                     self.context_menu.actionAddFco2Units.triggered.connect(self.add_fco2units_to_options)
+                if "DisableWPL" not in existing_entries:
+                    self.context_menu.actionAddDisableWPL = QtWidgets.QAction(self)
+                    self.context_menu.actionAddDisableWPL.setText("DisableWPL")
+                    self.context_menu.addAction(self.context_menu.actionAddDisableWPL)
+                    self.context_menu.actionAddDisableWPL.triggered.connect(self.add_DisableWPL_to_options)
             elif selected_text == "Massman":
                 self.context_menu.actionRemoveMassmanSection = QtWidgets.QAction(self)
                 self.context_menu.actionRemoveMassmanSection.setText("Remove section")
@@ -3424,7 +3437,7 @@ class edit_cfg_L3(QtWidgets.QWidget):
                 elif (selected_item.column() == 1) and (key in ["ApplyFco2Storage", "UseL2Fluxes",
                                                                 "2DCoordRotation", "MassmanCorrection",
                                                                 "CorrectIndividualFg", "CorrectFgForStorage",
-                                                                "KeepIntermediateSeries"]):
+                                                                "KeepIntermediateSeries", "DisableWPL"]):
                     if selected_text != "Yes":
                         self.context_menu.actionChangeOption = QtWidgets.QAction(self)
                         self.context_menu.actionChangeOption.setText("Yes")

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -275,18 +275,32 @@ class file_explore(QtWidgets.QWidget):
         if len(self.view.selectedIndexes()) == 0:
             # trap right click when nothing is selected
             return
+        # get the indices of selected items
         idx = self.view.selectedIndexes()
-        #groups = list(set([i.parent().parent().data() for i in idx]))
+        # get the group labels of selected items
         groups = list(set([i.parent().data() for i in idx]))
+        # dictionary to hold the labels of selected variables for each group
         selections = {}
-        for group in groups:
-            selections[group] = []
+        # add the selected variable labels to the right group in selections
         for i in idx:
+            # get the group label of this selected item
+            group = i.parent().data()
+            # skip anything selected in 'Global attributes'
+            if (group in ["Global attributes"]):
+                continue
+            # add the group to selections if not there
+            if group not in selections:
+                selections[group] = []
+            # append the label of the selected variable to the group
             selections[i.parent().data()].append(i.data())
-        for key in selections.keys():
+        # rename the 'Variables' group to 'root'
+        for key in list(selections.keys()):
             if key is None or key == "Variables":
                 selections["root"] = selections.pop(key)
                 break
+        # return if selections is empty (no variables selected)
+        if len(list(selections.keys())) == 0:
+            return
         # plot time series, separate axes or grouped
         menuPlotTimeSeries = QtWidgets.QMenu(self)
         menuPlotTimeSeries.setTitle("Plot time series")
@@ -307,6 +321,7 @@ class file_explore(QtWidgets.QWidget):
         # plot fingerprints
         # check the time steps for all groups containing selected variables
         groups = list(selections.keys())
+        groups = ["root" if i == "Global attributes" else i for i in groups]
         time_steps = []
         for group in groups:
             time_steps.append(str(getattr(self.ds, group)["Attributes"]["time_step"]))
@@ -355,6 +370,7 @@ class file_explore(QtWidgets.QWidget):
         for gattr in gattrs:
             value = str(self.ds.root["Attributes"][gattr])
             child0 = QtGui.QStandardItem(gattr)
+            child0.setEditable(False)
             child1 = QtGui.QStandardItem(value)
             section.appendRow([child0, child1])
         self.model.appendRow([section, long_name])

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -32,6 +32,59 @@ class myMessageBox(QtWidgets.QMessageBox):
         self.setStandardButtons(QtWidgets.QMessageBox.Ok)
         self.exec_()
 
+class MsgBox_Close(QtWidgets.QMessageBox):
+    def __init__(self, msg, title="Information", parent=None):
+        super(MsgBox_Close, self).__init__(parent)
+        if title in ["Critical", "Error"]:
+            self.setIcon(QtWidgets.QMessageBox.Critical)
+        elif title == "Warning":
+            self.setIcon(QtWidgets.QMessageBox.Warning)
+        else:
+            self.setIcon(QtWidgets.QMessageBox.Information)
+        self.setText(msg)
+        self.setWindowTitle(title)
+        self.setStandardButtons(QtWidgets.QMessageBox.No)
+        self.button(QtWidgets.QMessageBox.No).setText("Close")
+        self.setModal(False)
+        self.show()
+        self.exec_()
+
+class MsgBox_CloseOrIgnore(QtWidgets.QMessageBox):
+    def __init__(self, msg, title="Information", parent=None):
+        super(MsgBox_CloseOrIgnore, self).__init__(parent)
+        if title == "Critical":
+            self.setIcon(QtWidgets.QMessageBox.Critical)
+        elif title == "Warning":
+            self.setIcon(QtWidgets.QMessageBox.Warning)
+        else:
+            self.setIcon(QtWidgets.QMessageBox.Information)
+        self.setText(msg)
+        self.setWindowTitle(title)
+        self.setStandardButtons(QtWidgets.QMessageBox.Yes |
+                                QtWidgets.QMessageBox.No)
+        self.button(QtWidgets.QMessageBox.Yes).setText("Ignore")
+        self.button(QtWidgets.QMessageBox.No).setText("Close")
+        self.setModal(False)
+        self.show()
+        self.exec_()
+
+class MsgBox_Continue(QtWidgets.QMessageBox):
+    def __init__(self, msg, title="Information", parent=None):
+        super(MsgBox_Continue, self).__init__(parent)
+        if title in ["Critical", "Error"]:
+            self.setIcon(QtWidgets.QMessageBox.Critical)
+        elif title == "Warning":
+            self.setIcon(QtWidgets.QMessageBox.Warning)
+        else:
+            self.setIcon(QtWidgets.QMessageBox.Information)
+        self.setText(msg)
+        self.setWindowTitle(title)
+        self.setStandardButtons(QtWidgets.QMessageBox.Yes)
+        self.button(QtWidgets.QMessageBox.Yes).setText("Continue")
+        self.setModal(False)
+        self.show()
+        self.exec_()
+
 class MsgBox_ContinueOrQuit(QtWidgets.QMessageBox):
     def __init__(self, msg, title="Information", parent=None):
         super(MsgBox_ContinueOrQuit, self).__init__(parent)
@@ -64,23 +117,6 @@ class MsgBox_Quit(QtWidgets.QMessageBox):
         self.setWindowTitle(title)
         self.setStandardButtons(QtWidgets.QMessageBox.No)
         self.button(QtWidgets.QMessageBox.No).setText("Quit")
-        self.setModal(False)
-        self.show()
-        self.exec_()
-
-class MsgBox_Continue(QtWidgets.QMessageBox):
-    def __init__(self, msg, title="Information", parent=None):
-        super(MsgBox_Continue, self).__init__(parent)
-        if title in ["Critical", "Error"]:
-            self.setIcon(QtWidgets.QMessageBox.Critical)
-        elif title == "Warning":
-            self.setIcon(QtWidgets.QMessageBox.Warning)
-        else:
-            self.setIcon(QtWidgets.QMessageBox.Information)
-        self.setText(msg)
-        self.setWindowTitle(title)
-        self.setStandardButtons(QtWidgets.QMessageBox.Yes)
-        self.button(QtWidgets.QMessageBox.Yes).setText("Continue")
         self.setModal(False)
         self.show()
         self.exec_()
@@ -2305,7 +2341,7 @@ class edit_cfg_L2(QtWidgets.QWidget):
                         self.context_menu.addAction(self.context_menu.actionSetCheckNo)
                         self.context_menu.actionSetCheckNo.triggered.connect(self.set_check_no)
             elif (str(parent.text()) == "Options") and (selected_item.column() == 0):
-                if selected_item.text() in ["SONIC_Check", "IRGA_Check"]:
+                if selected_item.text() in ["irga_type", "SONIC_Check", "IRGA_Check"]:
                     self.context_menu.actionRemoveOption = QtWidgets.QAction(self)
                     self.context_menu.actionRemoveOption.setText("Remove option")
                     self.context_menu.addAction(self.context_menu.actionRemoveOption)
@@ -2870,9 +2906,9 @@ class edit_cfg_L3(QtWidgets.QWidget):
         self.add_qc_check(selected_item, new_qc)
         self.update_tab_text()
 
-    def add_DisableWPL_to_options(self):
-        """ Add DisableWPL to the [Options] section."""
-        child0 = QtGui.QStandardItem("DisableWPL")
+    def add_ApplyWPL_to_options(self):
+        """ Add ApplyWPL to the [Options] section."""
+        child0 = QtGui.QStandardItem("ApplyWPL")
         child0.setEditable(False)
         child1 = QtGui.QStandardItem("Yes")
         self.sections["Options"].appendRow([child0, child1])
@@ -3363,11 +3399,11 @@ class edit_cfg_L3(QtWidgets.QWidget):
                     self.context_menu.actionAddFco2Units.setText("Fco2Units")
                     self.context_menu.addAction(self.context_menu.actionAddFco2Units)
                     self.context_menu.actionAddFco2Units.triggered.connect(self.add_fco2units_to_options)
-                if "DisableWPL" not in existing_entries:
-                    self.context_menu.actionAddDisableWPL = QtWidgets.QAction(self)
-                    self.context_menu.actionAddDisableWPL.setText("DisableWPL")
-                    self.context_menu.addAction(self.context_menu.actionAddDisableWPL)
-                    self.context_menu.actionAddDisableWPL.triggered.connect(self.add_DisableWPL_to_options)
+                if "ApplyWPL" not in existing_entries:
+                    self.context_menu.actionAddApplyWPL = QtWidgets.QAction(self)
+                    self.context_menu.actionAddApplyWPL.setText("ApplyWPL")
+                    self.context_menu.addAction(self.context_menu.actionAddApplyWPL)
+                    self.context_menu.actionAddApplyWPL.triggered.connect(self.add_ApplyWPL_to_options)
             elif selected_text == "Massman":
                 self.context_menu.actionRemoveMassmanSection = QtWidgets.QAction(self)
                 self.context_menu.actionRemoveMassmanSection.setText("Remove section")
@@ -3437,7 +3473,7 @@ class edit_cfg_L3(QtWidgets.QWidget):
                 elif (selected_item.column() == 1) and (key in ["ApplyFco2Storage", "UseL2Fluxes",
                                                                 "2DCoordRotation", "MassmanCorrection",
                                                                 "CorrectIndividualFg", "CorrectFgForStorage",
-                                                                "KeepIntermediateSeries", "DisableWPL"]):
+                                                                "KeepIntermediateSeries", "ApplyWPL"]):
                     if selected_text != "Yes":
                         self.context_menu.actionChangeOption = QtWidgets.QAction(self)
                         self.context_menu.actionChangeOption.setText("Yes")

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -2770,6 +2770,14 @@ class edit_cfg_L3(QtWidgets.QWidget):
         self.add_qc_check(selected_item, new_qc)
         self.update_tab_text()
 
+    def add_DisableWPL_to_options(self):
+        """ Add DisableWPL to the [Options] section."""
+        child0 = QtGui.QStandardItem("DisableWPL")
+        child0.setEditable(False)
+        child1 = QtGui.QStandardItem("Yes")
+        self.sections["Options"].appendRow([child0, child1])
+        self.update_tab_text()
+
     def add_diurnalcheck(self):
         """ Add a diurnal check to a variable."""
         new_qc = {"DiurnalCheck":{"numsd":"5"}}
@@ -3255,6 +3263,11 @@ class edit_cfg_L3(QtWidgets.QWidget):
                     self.context_menu.actionAddFco2Units.setText("Fco2Units")
                     self.context_menu.addAction(self.context_menu.actionAddFco2Units)
                     self.context_menu.actionAddFco2Units.triggered.connect(self.add_fco2units_to_options)
+                if "DisableWPL" not in existing_entries:
+                    self.context_menu.actionAddDisableWPL = QtWidgets.QAction(self)
+                    self.context_menu.actionAddDisableWPL.setText("DisableWPL")
+                    self.context_menu.addAction(self.context_menu.actionAddDisableWPL)
+                    self.context_menu.actionAddDisableWPL.triggered.connect(self.add_DisableWPL_to_options)
             elif selected_text == "Massman":
                 self.context_menu.actionRemoveMassmanSection = QtWidgets.QAction(self)
                 self.context_menu.actionRemoveMassmanSection.setText("Remove section")
@@ -3324,7 +3337,7 @@ class edit_cfg_L3(QtWidgets.QWidget):
                 elif (selected_item.column() == 1) and (key in ["ApplyFco2Storage", "UseL2Fluxes",
                                                                 "2DCoordRotation", "MassmanCorrection",
                                                                 "CorrectIndividualFg", "CorrectFgForStorage",
-                                                                "KeepIntermediateSeries"]):
+                                                                "KeepIntermediateSeries", "DisableWPL"]):
                     if selected_text != "Yes":
                         self.context_menu.actionChangeOption = QtWidgets.QAction(self)
                         self.context_menu.actionChangeOption.setText("Yes")

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -65,8 +65,13 @@ class MsgBox_CloseOrIgnore(QtWidgets.QMessageBox):
         self.button(QtWidgets.QMessageBox.Yes).setText("Ignore")
         self.button(QtWidgets.QMessageBox.No).setText("Close")
         self.setModal(False)
-        self.show()
+        #self.show()
+    def execute(self):
         self.exec_()
+        if self.clickedButton() is self.button(QtWidgets.QMessageBox.Yes):
+            return "ignore"
+        else:
+            return "close"
 
 class MsgBox_Continue(QtWidgets.QMessageBox):
     def __init__(self, msg, title="Information", parent=None):
@@ -3058,9 +3063,9 @@ class edit_cfg_L3(QtWidgets.QWidget):
         self.sections["Plots"].appendRow(parent)
         self.update_tab_text()
 
-    def add_usel2fluxes(self):
-        """ Add UseL2Fluxes to the [Options] section."""
-        child0 = QtGui.QStandardItem("UseL2Fluxes")
+    def add_calculatefluxes(self):
+        """ Add CalculateFluxes to the [Options] section."""
+        child0 = QtGui.QStandardItem("CalculateFluxes")
         child0.setEditable(False)
         child1 = QtGui.QStandardItem("Yes")
         self.sections["Options"].appendRow([child0, child1])
@@ -3258,11 +3263,11 @@ class edit_cfg_L3(QtWidgets.QWidget):
                     self.context_menu.actionAddzms.setText("Add zms")
                     self.context_menu.addAction(self.context_menu.actionAddzms)
                     self.context_menu.actionAddzms.triggered.connect(self.add_zms)
-                if "UseL2Fluxes" not in existing_entries:
-                    self.context_menu.actionAddUseL2Fluxes = QtWidgets.QAction(self)
-                    self.context_menu.actionAddUseL2Fluxes.setText("UseL2Fluxes")
-                    self.context_menu.addAction(self.context_menu.actionAddUseL2Fluxes)
-                    self.context_menu.actionAddUseL2Fluxes.triggered.connect(self.add_usel2fluxes)
+                if "CalculateFluxes" not in existing_entries:
+                    self.context_menu.actionAddCalculateFluxes = QtWidgets.QAction(self)
+                    self.context_menu.actionAddCalculateFluxes.setText("CalculateFluxes")
+                    self.context_menu.addAction(self.context_menu.actionAddCalculateFluxes)
+                    self.context_menu.actionAddCalculateFluxes.triggered.connect(self.add_calculatefluxes)
                 if "2DCoordRotation" not in existing_entries:
                     self.context_menu.actionAdd2DCoordRotation = QtWidgets.QAction(self)
                     self.context_menu.actionAdd2DCoordRotation.setText("2DCoordRotation")
@@ -3374,7 +3379,7 @@ class edit_cfg_L3(QtWidgets.QWidget):
                     self.context_menu.actionRemoveOption.setText("Remove option")
                     self.context_menu.addAction(self.context_menu.actionRemoveOption)
                     self.context_menu.actionRemoveOption.triggered.connect(self.remove_item)
-                elif (selected_item.column() == 1) and (key in ["ApplyFco2Storage", "UseL2Fluxes",
+                elif (selected_item.column() == 1) and (key in ["ApplyFco2Storage", "CalculateFluxes",
                                                                 "2DCoordRotation", "MassmanCorrection",
                                                                 "CorrectIndividualFg", "CorrectFgForStorage",
                                                                 "KeepIntermediateSeries", "ApplyWPL"]):

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -45,9 +45,11 @@ class MsgBox_Close(QtWidgets.QMessageBox):
         self.setWindowTitle(title)
         self.setStandardButtons(QtWidgets.QMessageBox.No)
         self.button(QtWidgets.QMessageBox.No).setText("Close")
+    def execute(self):
         self.setModal(False)
         self.show()
         self.exec_()
+        return "close"
 
 class MsgBox_CloseOrIgnore(QtWidgets.QMessageBox):
     def __init__(self, msg, title="Information", parent=None):

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -64,9 +64,9 @@ class MsgBox_CloseOrIgnore(QtWidgets.QMessageBox):
                                 QtWidgets.QMessageBox.No)
         self.button(QtWidgets.QMessageBox.Yes).setText("Ignore")
         self.button(QtWidgets.QMessageBox.No).setText("Close")
-        self.setModal(False)
-        #self.show()
     def execute(self):
+        self.setModal(False)
+        self.show()
         self.exec_()
         if self.clickedButton() is self.button(QtWidgets.QMessageBox.Yes):
             return "ignore"
@@ -2001,6 +2001,17 @@ class edit_cfg_L2(QtWidgets.QWidget):
             self.sections["Options"].appendRow([child0, child1])
         self.update_tab_text()
 
+    def add_sonic_type(self):
+        """ Add sonic_type to Options section."""
+        new_options = {"sonic_type": "CSAT3"}
+        for key in new_options:
+            value = new_options[key]
+            child0 = QtGui.QStandardItem(key)
+            child0.setEditable(False)
+            child1 = QtGui.QStandardItem(value)
+            self.sections["Options"].appendRow([child0, child1])
+        self.update_tab_text()
+
     def add_subsection(self, section, dict_to_add):
         for key in dict_to_add:
             val = str(dict_to_add[key])
@@ -2239,6 +2250,12 @@ class edit_cfg_L2(QtWidgets.QWidget):
                     self.context_menu.addAction(self.context_menu.actionirgatype)
                     self.context_menu.actionirgatype.triggered.connect(self.add_irga_type)
                     add_separator = True
+                if "sonic_type" not in existing_entries:
+                    self.context_menu.actionsonictype = QtWidgets.QAction(self)
+                    self.context_menu.actionsonictype.setText("sonic_type")
+                    self.context_menu.addAction(self.context_menu.actionsonictype)
+                    self.context_menu.actionsonictype.triggered.connect(self.add_sonic_type)
+                    add_separator = True
                 if "SONIC_Check" not in existing_entries:
                     self.context_menu.actionSonicCheck = QtWidgets.QAction(self)
                     self.context_menu.actionSonicCheck.setText("SONIC_Check")
@@ -2344,6 +2361,18 @@ class edit_cfg_L2(QtWidgets.QWidget):
                         self.context_menu.actionSetIRGATypeIRGASON.setText("IRGASON")
                         self.context_menu.addAction(self.context_menu.actionSetIRGATypeIRGASON)
                         self.context_menu.actionSetIRGATypeIRGASON.triggered.connect(self.set_irga_irgason)
+                elif key == "sonic_type":
+                    existing_entry = str(parent.child(selected_item.row(),1).text())
+                    if existing_entry != "CSAT3":
+                        self.context_menu.actionSetSonicTypeCSAT3 = QtWidgets.QAction(self)
+                        self.context_menu.actionSetSonicTypeCSAT3.setText("CSAT3")
+                        self.context_menu.addAction(self.context_menu.actionSetSonicTypeCSAT3)
+                        self.context_menu.actionSetSonicTypeCSAT3.triggered.connect(self.set_sonic_csat3)
+                    if existing_entry != "CSAT3B":
+                        self.context_menu.actionSetSonicTypeCSAT3B = QtWidgets.QAction(self)
+                        self.context_menu.actionSetSonicTypeCSAT3B.setText("CSAT3B")
+                        self.context_menu.addAction(self.context_menu.actionSetSonicTypeCSAT3B)
+                        self.context_menu.actionSetSonicTypeCSAT3B.triggered.connect(self.set_sonic_csat3b)
                 elif key in ["SONIC_Check", "IRGA_Check"]:
                     existing_entry = str(parent.child(selected_item.row(),1).text())
                     if existing_entry != "Yes":
@@ -2357,7 +2386,7 @@ class edit_cfg_L2(QtWidgets.QWidget):
                         self.context_menu.addAction(self.context_menu.actionSetCheckNo)
                         self.context_menu.actionSetCheckNo.triggered.connect(self.set_check_no)
             elif (str(parent.text()) == "Options") and (selected_item.column() == 0):
-                if selected_item.text() in ["irga_type", "SONIC_Check", "IRGA_Check"]:
+                if selected_item.text() in ["irga_type", "sonic_type", "SONIC_Check", "IRGA_Check"]:
                     self.context_menu.actionRemoveOption = QtWidgets.QAction(self)
                     self.context_menu.actionRemoveOption.setText("Remove option")
                     self.context_menu.addAction(self.context_menu.actionRemoveOption)
@@ -2822,6 +2851,20 @@ class edit_cfg_L2(QtWidgets.QWidget):
         selected_item = idx.model().itemFromIndex(idx)
         parent = selected_item.parent()
         parent.child(selected_item.row(), 1).setText("Li-7200RS")
+
+    def set_sonic_csat3(self):
+        """ Set the sonic type to CSAT3."""
+        idx = self.view.selectedIndexes()[0]
+        selected_item = idx.model().itemFromIndex(idx)
+        parent = selected_item.parent()
+        parent.child(selected_item.row(), 1).setText("CSAT3")
+
+    def set_sonic_csat3b(self):
+        """ Set the sonic type to CSAT3B."""
+        idx = self.view.selectedIndexes()[0]
+        selected_item = idx.model().itemFromIndex(idx)
+        parent = selected_item.parent()
+        parent.child(selected_item.row(), 1).setText("CSAT3B")
 
     def update_tab_text(self):
         """ Add an asterisk to the tab title text to indicate tab contents have changed."""
@@ -3782,7 +3825,7 @@ class edit_cfg_L3(QtWidgets.QWidget):
                 # sections with only 1 level
                 self.sections[key1] = QtGui.QStandardItem(key1)
                 self.sections[key1].setEditable(False)
-                for key2 in self.cfg[key1]:
+                for key2 in sorted(list(self.cfg[key1].keys())):
                     value = self.cfg[key1][key2]
                     child0 = QtGui.QStandardItem(key2)
                     child0.setEditable(False)

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -32,6 +32,59 @@ class myMessageBox(QtWidgets.QMessageBox):
         self.setStandardButtons(QtWidgets.QMessageBox.Ok)
         self.exec_()
 
+class MsgBox_Close(QtWidgets.QMessageBox):
+    def __init__(self, msg, title="Information", parent=None):
+        super(MsgBox_Close, self).__init__(parent)
+        if title in ["Critical", "Error"]:
+            self.setIcon(QtWidgets.QMessageBox.Critical)
+        elif title == "Warning":
+            self.setIcon(QtWidgets.QMessageBox.Warning)
+        else:
+            self.setIcon(QtWidgets.QMessageBox.Information)
+        self.setText(msg)
+        self.setWindowTitle(title)
+        self.setStandardButtons(QtWidgets.QMessageBox.No)
+        self.button(QtWidgets.QMessageBox.No).setText("Close")
+        self.setModal(False)
+        self.show()
+        self.exec_()
+
+class MsgBox_CloseOrIgnore(QtWidgets.QMessageBox):
+    def __init__(self, msg, title="Information", parent=None):
+        super(MsgBox_CloseOrIgnore, self).__init__(parent)
+        if title == "Critical":
+            self.setIcon(QtWidgets.QMessageBox.Critical)
+        elif title == "Warning":
+            self.setIcon(QtWidgets.QMessageBox.Warning)
+        else:
+            self.setIcon(QtWidgets.QMessageBox.Information)
+        self.setText(msg)
+        self.setWindowTitle(title)
+        self.setStandardButtons(QtWidgets.QMessageBox.Yes |
+                                QtWidgets.QMessageBox.No)
+        self.button(QtWidgets.QMessageBox.Yes).setText("Ignore")
+        self.button(QtWidgets.QMessageBox.No).setText("Close")
+        self.setModal(False)
+        self.show()
+        self.exec_()
+
+class MsgBox_Continue(QtWidgets.QMessageBox):
+    def __init__(self, msg, title="Information", parent=None):
+        super(MsgBox_Continue, self).__init__(parent)
+        if title in ["Critical", "Error"]:
+            self.setIcon(QtWidgets.QMessageBox.Critical)
+        elif title == "Warning":
+            self.setIcon(QtWidgets.QMessageBox.Warning)
+        else:
+            self.setIcon(QtWidgets.QMessageBox.Information)
+        self.setText(msg)
+        self.setWindowTitle(title)
+        self.setStandardButtons(QtWidgets.QMessageBox.Yes)
+        self.button(QtWidgets.QMessageBox.Yes).setText("Continue")
+        self.setModal(False)
+        self.show()
+        self.exec_()
+
 class MsgBox_ContinueOrQuit(QtWidgets.QMessageBox):
     def __init__(self, msg, title="Information", parent=None):
         super(MsgBox_ContinueOrQuit, self).__init__(parent)
@@ -64,23 +117,6 @@ class MsgBox_Quit(QtWidgets.QMessageBox):
         self.setWindowTitle(title)
         self.setStandardButtons(QtWidgets.QMessageBox.No)
         self.button(QtWidgets.QMessageBox.No).setText("Quit")
-        self.setModal(False)
-        self.show()
-        self.exec_()
-
-class MsgBox_Continue(QtWidgets.QMessageBox):
-    def __init__(self, msg, title="Information", parent=None):
-        super(MsgBox_Continue, self).__init__(parent)
-        if title in ["Critical", "Error"]:
-            self.setIcon(QtWidgets.QMessageBox.Critical)
-        elif title == "Warning":
-            self.setIcon(QtWidgets.QMessageBox.Warning)
-        else:
-            self.setIcon(QtWidgets.QMessageBox.Information)
-        self.setText(msg)
-        self.setWindowTitle(title)
-        self.setStandardButtons(QtWidgets.QMessageBox.Yes)
-        self.button(QtWidgets.QMessageBox.Yes).setText("Continue")
         self.setModal(False)
         self.show()
         self.exec_()
@@ -2205,7 +2241,7 @@ class edit_cfg_L2(QtWidgets.QWidget):
                         self.context_menu.addAction(self.context_menu.actionSetCheckNo)
                         self.context_menu.actionSetCheckNo.triggered.connect(self.set_check_no)
             elif (str(parent.text()) == "Options") and (selected_item.column() == 0):
-                if selected_item.text() in ["SONIC_Check", "IRGA_Check"]:
+                if selected_item.text() in ["irga_type", "SONIC_Check", "IRGA_Check"]:
                     self.context_menu.actionRemoveOption = QtWidgets.QAction(self)
                     self.context_menu.actionRemoveOption.setText("Remove option")
                     self.context_menu.addAction(self.context_menu.actionRemoveOption)
@@ -2770,9 +2806,9 @@ class edit_cfg_L3(QtWidgets.QWidget):
         self.add_qc_check(selected_item, new_qc)
         self.update_tab_text()
 
-    def add_DisableWPL_to_options(self):
-        """ Add DisableWPL to the [Options] section."""
-        child0 = QtGui.QStandardItem("DisableWPL")
+    def add_ApplyWPL_to_options(self):
+        """ Add ApplyWPL to the [Options] section."""
+        child0 = QtGui.QStandardItem("ApplyWPL")
         child0.setEditable(False)
         child1 = QtGui.QStandardItem("Yes")
         self.sections["Options"].appendRow([child0, child1])
@@ -3263,11 +3299,11 @@ class edit_cfg_L3(QtWidgets.QWidget):
                     self.context_menu.actionAddFco2Units.setText("Fco2Units")
                     self.context_menu.addAction(self.context_menu.actionAddFco2Units)
                     self.context_menu.actionAddFco2Units.triggered.connect(self.add_fco2units_to_options)
-                if "DisableWPL" not in existing_entries:
-                    self.context_menu.actionAddDisableWPL = QtWidgets.QAction(self)
-                    self.context_menu.actionAddDisableWPL.setText("DisableWPL")
-                    self.context_menu.addAction(self.context_menu.actionAddDisableWPL)
-                    self.context_menu.actionAddDisableWPL.triggered.connect(self.add_DisableWPL_to_options)
+                if "ApplyWPL" not in existing_entries:
+                    self.context_menu.actionAddApplyWPL = QtWidgets.QAction(self)
+                    self.context_menu.actionAddApplyWPL.setText("ApplyWPL")
+                    self.context_menu.addAction(self.context_menu.actionAddApplyWPL)
+                    self.context_menu.actionAddApplyWPL.triggered.connect(self.add_ApplyWPL_to_options)
             elif selected_text == "Massman":
                 self.context_menu.actionRemoveMassmanSection = QtWidgets.QAction(self)
                 self.context_menu.actionRemoveMassmanSection.setText("Remove section")
@@ -3337,7 +3373,7 @@ class edit_cfg_L3(QtWidgets.QWidget):
                 elif (selected_item.column() == 1) and (key in ["ApplyFco2Storage", "UseL2Fluxes",
                                                                 "2DCoordRotation", "MassmanCorrection",
                                                                 "CorrectIndividualFg", "CorrectFgForStorage",
-                                                                "KeepIntermediateSeries", "DisableWPL"]):
+                                                                "KeepIntermediateSeries", "ApplyWPL"]):
                     if selected_text != "Yes":
                         self.context_menu.actionChangeOption = QtWidgets.QAction(self)
                         self.context_menu.actionChangeOption.setText("Yes")

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -2006,7 +2006,7 @@ class edit_cfg_L2(QtWidgets.QWidget):
 
     def add_sonic_type(self):
         """ Add sonic_type to Options section."""
-        new_options = {"sonic_type": "CSAT3"}
+        new_options = {"sonic_type": "CSAT3B"}
         for key in new_options:
             value = new_options[key]
             child0 = QtGui.QStandardItem(key)
@@ -2371,6 +2371,11 @@ class edit_cfg_L2(QtWidgets.QWidget):
                         self.context_menu.actionSetSonicTypeCSAT3.setText("CSAT3")
                         self.context_menu.addAction(self.context_menu.actionSetSonicTypeCSAT3)
                         self.context_menu.actionSetSonicTypeCSAT3.triggered.connect(self.set_sonic_csat3)
+                    if existing_entry != "CSAT3A":
+                        self.context_menu.actionSetSonicTypeCSAT3A = QtWidgets.QAction(self)
+                        self.context_menu.actionSetSonicTypeCSAT3A.setText("CSAT3A")
+                        self.context_menu.addAction(self.context_menu.actionSetSonicTypeCSAT3A)
+                        self.context_menu.actionSetSonicTypeCSAT3A.triggered.connect(self.set_sonic_csat3a)
                     if existing_entry != "CSAT3B":
                         self.context_menu.actionSetSonicTypeCSAT3B = QtWidgets.QAction(self)
                         self.context_menu.actionSetSonicTypeCSAT3B.setText("CSAT3B")
@@ -2861,6 +2866,13 @@ class edit_cfg_L2(QtWidgets.QWidget):
         selected_item = idx.model().itemFromIndex(idx)
         parent = selected_item.parent()
         parent.child(selected_item.row(), 1).setText("CSAT3")
+
+    def set_sonic_csat3a(self):
+        """ Set the sonic type to CSAT3A."""
+        idx = self.view.selectedIndexes()[0]
+        selected_item = idx.model().itemFromIndex(idx)
+        parent = selected_item.parent()
+        parent.child(selected_item.row(), 1).setText("CSAT3A")
 
     def set_sonic_csat3b(self):
         """ Set the sonic type to CSAT3B."""

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -644,7 +644,9 @@ def ReadExcelWorkbook(l1_info):
             if xl_label not in headers:
                 msg = " Variable " + xl_label + " not found on sheet " + xl_sheet + ", skipping ..."
                 logger.warning(msg)
+                nc_label = l1ire["xl_sheets"][xl_sheet]["xl_labels"][xl_label]
                 del l1ire["xl_sheets"][xl_sheet]["xl_labels"][xl_label]
+                del l1ire["xl_sheets"][xl_sheet]["nc_labels"][nc_label]
     df_names = list(dfs)
     for df_name in df_names:
         timestamps = list(dfs[df_name].select_dtypes(include=['datetime64']))

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -667,7 +667,9 @@ def ReadExcelWorkbook(l1_info):
             if xl_label not in headers:
                 msg = " Variable " + xl_label + " not found on sheet " + xl_sheet + ", skipping ..."
                 logger.warning(msg)
+                nc_label = l1ire["xl_sheets"][xl_sheet]["xl_labels"][xl_label]
                 del l1ire["xl_sheets"][xl_sheet]["xl_labels"][xl_label]
+                del l1ire["xl_sheets"][xl_sheet]["nc_labels"][nc_label]
     df_names = list(dfs)
     for df_name in df_names:
         timestamps = list(dfs[df_name].select_dtypes(include=['datetime64']))

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -2356,6 +2356,13 @@ def nc_read_series(nc_file, checktimestep=True, fixtimestepmethod="round"):
     if len(gattrlist) != 0:
         for gattr in gattrlist:
             ds.root["Attributes"][gattr] = getattr(nc_file, gattr)
+    if "processing_level" not in ds.root["Attributes"]:
+        if "nc_level" in ds.root["Attributes"]:
+            ds.root["Attributes"]["processing_level"] = ds.root["Attributes"]["nc_level"]
+        else:
+            msg = "  No processing level in global attributes, set to unknown"
+            logger.warning(msg)
+            ds.root["Attributes"]["processing_level"] = "unknown"
     # get a list of the variables in the netCDF file (not their QC flags)
     varlist = [x for x in list(nc_file.variables.keys()) if "_QCFlag" not in x]
     for ThisOne in varlist:

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -657,8 +657,9 @@ def ReadExcelWorkbook(l1_info):
             del l1ire["Variables"][nc_label]
             continue
         if xl_sheet not in l1ire["xl_sheets"]:
-            l1ire["xl_sheets"][xl_sheet] = {"DateTime": "", "xl_labels":{}}
+            l1ire["xl_sheets"][xl_sheet] = {"DateTime": "", "xl_labels":{}, "nc_labels":{}}
         l1ire["xl_sheets"][xl_sheet]["xl_labels"][xl_label] = nc_label
+        l1ire["xl_sheets"][xl_sheet]["nc_labels"][nc_label] = xl_label
     # check the requested variables are on the specified sheets
     for xl_sheet in list(l1ire["xl_sheets"].keys()):
         headers = list(dfs[xl_sheet])
@@ -703,8 +704,15 @@ def ReadExcelWorkbook(l1_info):
         dfs[df_name][cols] = dfs[df_name][cols].apply(pandas.to_numeric, errors='coerce')
     # rename the pandas dataframe columns from the Excel variable names to the netCDF
     # variable names
+    # loop over the sheets in the Excel workbook
     for df_name in df_names:
-        dfs[df_name] = dfs[df_name].rename(columns=l1ire["xl_sheets"][df_name]["xl_labels"])
+        # create an empty dataframe with the index
+        tmp = pandas.DataFrame(index=dfs[df_name].index)
+        # loop over the netCDF variable names, done to allow variables with duplicate values
+        for l in list(l1ire["xl_sheets"][df_name]["nc_labels"].keys()):
+            tmp[l] = dfs[df_name][l1ire["xl_sheets"][df_name]["nc_labels"][l]].copy()
+        # copy the new dataframe to the old name
+        dfs[df_name] = tmp.copy()
     pfp_log.debug_function_leave(inspect.currentframe().f_code.co_name)
     return dfs
 

--- a/scripts/pfp_levels.py
+++ b/scripts/pfp_levels.py
@@ -141,7 +141,7 @@ def l3qc(cf, ds2):
     # *** Calculate fluxes from covariances section ***
     # *************************************************
     # check to see if the user wants to use the fluxes in the L2 file
-    if not pfp_utils.get_optionskeyaslogical(cf, "UseL2Fluxes", default=False):
+    if pfp_utils.get_optionskeyaslogical(cf, "CalculateFluxes", default=True):
         # check the covariance units and change if necessary
         pfp_ts.CheckCovarianceUnits(ds3)
         # do the 2D coordinate rotation

--- a/scripts/pfp_levels.py
+++ b/scripts/pfp_levels.py
@@ -163,11 +163,12 @@ def l3qc(cf, ds2):
     # convert CO2 units if required
     pfp_utils.ConvertCO2Units(cf, ds3)
     # calculate Fco2 storage term - single height only at present
-    pfp_ts.CalculateFco2StorageSinglePoint(cf, ds3, l3_info)
-    # convert Fco2 units if required
+    pfp_ts.CalculateSco2SinglePoint(cf, ds3, l3_info)
+    # convert Fco2 and Sco2 units if required
     pfp_utils.ConvertFco2Units(cf, ds3)
-    # merge Fco2 and Fco2_storage series if required
+    # merge Fco2 and Sco2 series as required
     pfp_ts.CombineSeries(cf, ds3, l3_info["Fco2"]["combine_list"])
+    pfp_ts.CombineSeries(cf, ds3, l3_info["Sco2"]["combine_list"])
     # correct Fco2 for storage term - only recommended if storage calculated from profile available
     pfp_ts.CorrectFco2ForStorage(cf, ds3)
     # *************************

--- a/scripts/pfp_part.py
+++ b/scripts/pfp_part.py
@@ -178,12 +178,17 @@ class partition(object):
     #--------------------------------------------------------------------------
 
     #--------------------------------------------------------------------------
-    def estimate_Eo(self, window_size = 15, window_step = 5, get_stats = False):
+    #def estimate_Eo(self, window_size = 15, window_step = 5, get_stats = False):
+    def estimate_Eo(self, get_stats = False):
 
         """Estimate the activation energy type parameter for the L&T Arrhenius
            style equation using nocturnal data"""
 
         Eo_list = []
+        called_by = self.l6_info["Options"]["called_by"]
+        output = self.l6_info["Options"]["output"]
+        window_size = int(self.l6_info[called_by]["outputs"][output]["window_size_days"])
+        window_step = int(self.l6_info[called_by]["outputs"][output]["step_size_days"])
         for n, date in enumerate(self.make_date_iterator(window_size, window_step)):
             self.results["E0"][n] = {"start": date, "end": date,
                                      "num": 0, "T range": -9999,

--- a/scripts/pfp_part.py
+++ b/scripts/pfp_part.py
@@ -14,6 +14,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from scripts import pfp_utils
+
 logger = logging.getLogger("pfp_log")
 
 #------------------------------------------------------------------------------
@@ -235,6 +237,14 @@ class partition(object):
                     continue
             else:
                 continue
+        # check to see if the raw LL plot was produced by checking the LL_fignum attribute
+        if hasattr(self, "LL_fignum"):
+            # check to see if a figure with this number exists
+            if plt.fignum_exists(self.LL_fignum):
+                # close the plot
+                plt.close(self.LL_fignum)
+                # delete the attribute
+                delattr(self, "LL_fignum")
         E0_results = pd.DataFrame.from_dict(self.results["E0"], orient="index")
         E0_results.to_excel(self.xl_writer, "E0 results")
         if len(Eo_list) == 0:
@@ -320,6 +330,14 @@ class partition(object):
                 #msg = '- {}'.format(e)
                 #logger.error(msg)
                 continue
+        # check to see if the raw LL plot was produced by checking the LL_fignum attribute
+        if hasattr(self, "LL_fignum"):
+            # check to see if a figure with this number exists
+            if plt.fignum_exists(self.LL_fignum):
+                # close the plot
+                plt.close(self.LL_fignum)
+                # delete the attribute
+                delattr(self, "LL_fignum")
         full_date_list = np.unique(self.df.index.date)
         flag = pd.Series(0, index = date_list, name = 'Fill_flag')
         flag = flag.reindex(pd.date_range(full_date_list[0], full_date_list[-1],
@@ -515,10 +533,26 @@ class partition(object):
         title = np.datetime_as_string(df.index.values[0], unit='D') + " to "
         title += np.datetime_as_string(df.index.values[-1], unit='D')
         file_name = os.path.join("plots", "estimate_e0_" + title.replace(" ", "_") + ".png")
-        current_backend = plt.get_backend()
-        plt.switch_backend("agg")
-        plt.ioff()
-        fig, axs = plt.subplots()
+
+        if hasattr(self, 'E0_fignum'):
+            pass
+        else:
+            self.E0_fignum = plt.get_fignums()[-1] + 1
+
+        if self.l6_info["Options"]["call_mode"] == "interactive":
+            plt.ion()
+        else:
+            current_backend = plt.get_backend()
+            plt.switch_backend("agg")
+            plt.ioff()
+
+        if plt.fignum_exists(self.E0_fignum):
+            fig = plt.figure(self.E0_fignum)
+            plt.clf()
+            axs = fig.add_subplot(1, 1, 1)
+        else:
+            fig, axs = plt.subplots(num=self.E0_fignum, figsize=(8, 8))
+
         if "Sws" in list(self.df):
             ldf = self.df[self.df.index.isin(df.index)]
             sc = axs.scatter(df.TC.values, df.ER.values, c=ldf.Sws.values, s=10)
@@ -530,9 +564,15 @@ class partition(object):
         clb = plt.colorbar(sc)
         clb.ax.set_title("Sws")
         fig.savefig(file_name, format="png")
-        plt.close(fig)
-        plt.switch_backend(current_backend)
-        plt.ion()
+
+        if self.l6_info["Options"]["call_mode"] == "interactive":
+            plt.draw()
+            pfp_utils.mypause(0.5)
+            plt.ioff()
+        else:
+            plt.close()
+            plt.switch_backend(current_backend)
+            plt.ion()
         return
     #--------------------------------------------------------------------------
 
@@ -541,10 +581,26 @@ class partition(object):
         title = np.datetime_as_string(df.index.values[0], unit='D') + " to "
         title += np.datetime_as_string(df.index.values[-1], unit='D')
         file_name = os.path.join("plots", "LL_" + title.replace(" ", "_") + ".png")
-        current_backend = plt.get_backend()
-        plt.switch_backend("agg")
-        plt.ioff()
-        fig, axs = plt.subplots()
+
+        if hasattr(self, 'LL_fignum'):
+            pass
+        else:
+            self.LL_fignum = plt.get_fignums()[-1] + 1
+
+        if self.l6_info["Options"]["call_mode"] == "interactive":
+            plt.ion()
+        else:
+            current_backend = plt.get_backend()
+            plt.switch_backend("agg")
+            plt.ioff()
+
+        if plt.fignum_exists(self.LL_fignum):
+            fig = plt.figure(self.LL_fignum)
+            plt.clf()
+            axs = fig.add_subplot(1, 1, 1)
+        else:
+            fig, axs = plt.subplots(num=self.LL_fignum, figsize=(8, 8))
+
         sc = axs.scatter(df.PPFD.values, df.NEE.values, c=df.VPD.values, s=10)
         axs.set_title(title)
         axs.set_xlabel("PPFD (umol/m^2/s)")
@@ -552,9 +608,16 @@ class partition(object):
         clb = plt.colorbar(sc)
         clb.ax.set_title("VPD")
         fig.savefig(file_name, format="png")
-        plt.close(fig)
-        plt.switch_backend(current_backend)
-        plt.ion()
+
+        if self.l6_info["Options"]["call_mode"] == "interactive":
+            plt.draw()
+            pfp_utils.mypause(0.5)
+            plt.ioff()
+        else:
+            plt.close()
+            plt.switch_backend(current_backend)
+            plt.ion()
+
         return
     #--------------------------------------------------------------------------
 

--- a/scripts/pfp_rp.py
+++ b/scripts/pfp_rp.py
@@ -2161,11 +2161,13 @@ def rp_plot(pd, ds, output, drivers, target, iel, called_by, si=0, ei=-1):
     if iel["gui"]["show_plots"]:
         plt.ion()
     else:
+        current_backend = plt.get_backend()
+        plt.switch_backend("agg")
         plt.ioff()
     fig = plt.figure(pd["fig_num"], figsize=(13, 8))
     fig.clf()
-    fig.canvas.set_window_title(target + " (" + mode + "): " + pd["startdate"]
-                                + " to " + pd["enddate"])
+    fig.canvas.manager.set_window_title(target + " (" + mode + "): " + pd["startdate"]
+                                        + " to " + pd["enddate"])
     plt.figtext(0.5, 0.95, pd["title"], ha='center', size=16)
     # XY plot of the diurnal variation
     rect1 = [0.10, pd["margin_bottom"], pd["xy_width"], pd["xy_height"]]
@@ -2272,9 +2274,11 @@ def rp_plot(pd, ds, output, drivers, target, iel, called_by, si=0, ei=-1):
     # draw the plot on the screen
     if iel["gui"]["show_plots"]:
         plt.draw()
-        pfp_utils.mypause(1)
+        pfp_utils.mypause(0.5)
         plt.ioff()
     else:
-        plt.close(fig)
+        #plt.close(fig)
+        plt.close()
+        plt.switch_backend(current_backend)
         plt.ion()
     return

--- a/scripts/pfp_rp.py
+++ b/scripts/pfp_rp.py
@@ -2084,7 +2084,10 @@ def rp_createdict_outputs(cf, l6_info, target, called_by, flag_code):
         l6_info["RemoveIntermediateSeries"]["not_output"].append(output)
         # create the dictionary keys for this series
         eo[output] = {}
-        # get the target
+        # get the output options
+        for key in list(cf[section][target][called_by][output].keys()):
+            eo[output][key] = cf[section][target][called_by][output][key]
+        # update the target and source
         sl = [section, target, called_by, output]
         eo[output]["target"] = pfp_utils.get_keyvaluefromcf(cf, sl, "target", default=target)
         eo[output]["source"] = pfp_utils.get_keyvaluefromcf(cf, sl, "source", default=target)

--- a/scripts/pfp_top_level.py
+++ b/scripts/pfp_top_level.py
@@ -669,21 +669,21 @@ def do_run_l6(main_gui):
         logger.error(error_message)
     return
 # top level routines for the Plot menu
-def do_plot_fcvsustar():
+def do_plot_fcvsustar_annual():
     """
     Purpose:
-     Plot Fc versus u*.
+     Plot Fc versus u* for each year.
     Usage:
-     pfp_top_level.do_plot_fcvsustar()
+     pfp_top_level.do_plot_fcvsustar_annual()
     Side effects:
-     Annual and seasonal plots of Fc versus u* to the screen and creates .PNG
+     Annual plots of Fc versus u* to the screen and creates .PNG
      hardcopies of the plots.
     Author: PRI
     Date: Back in the day
     Mods:
      December 2017: rewrite for use with new GUI
     """
-    logger.info("Starting Fc versus u* plots")
+    logger.info("Starting annual Fc versus u* plots")
     try:
         file_path = pfp_io.get_filename_dialog(file_path="../Sites",title="Choose a netCDF file")
         if len(file_path) == 0 or not os.path.isfile(file_path):
@@ -692,7 +692,71 @@ def do_plot_fcvsustar():
         ds = pfp_io.NetCDFRead(file_path)
         if ds.info["returncodes"]["value"] != 0: return
         logger.info("Plotting Fc versus u* ...")
-        pfp_plot.plot_fcvsustar(ds)
+        pfp_plot.plot_fcvsustar_annual(ds)
+        logger.info(" Finished plotting Fc versus u*")
+        logger.info("")
+    except Exception:
+        error_message = " An error occured while plotting Fc versus u*, see below for details ..."
+        logger.error(error_message)
+        error_message = traceback.format_exc()
+        logger.error(error_message)
+    return
+def do_plot_fcvsustar_seasonal():
+    """
+    Purpose:
+     Plot Fc versus u* for each season for each year.
+    Usage:
+     pfp_top_level.do_plot_fcvsustar_seasonal()
+    Side effects:
+     Seasonal plots of Fc versus u* to the screen and creates .PNG
+     hardcopies of the plots.
+    Author: PRI
+    Date: Back in the day
+    Mods:
+     December 2017: rewrite for use with new GUI
+    """
+    logger.info("Starting seasonal Fc versus u* plots")
+    try:
+        file_path = pfp_io.get_filename_dialog(file_path="../Sites",title="Choose a netCDF file")
+        if len(file_path) == 0 or not os.path.isfile(file_path):
+            return
+        # read the netCDF file
+        ds = pfp_io.NetCDFRead(file_path)
+        if ds.info["returncodes"]["value"] != 0: return
+        logger.info("Plotting Fc versus u* ...")
+        pfp_plot.plot_fcvsustar_seasonal(ds)
+        logger.info(" Finished plotting Fc versus u*")
+        logger.info("")
+    except Exception:
+        error_message = " An error occured while plotting Fc versus u*, see below for details ..."
+        logger.error(error_message)
+        error_message = traceback.format_exc()
+        logger.error(error_message)
+    return
+def do_plot_fcvsustar_monthly():
+    """
+    Purpose:
+     Plot Fc versus u* for each month for each year.
+    Usage:
+     pfp_top_level.do_plot_fcvsustar_monthly()
+    Side effects:
+     Monthly plots of Fc versus u* to the screen and creates .PNG
+     hardcopies of the plots.
+    Author: PRI
+    Date: Back in the day
+    Mods:
+     December 2017: rewrite for use with new GUI
+    """
+    logger.info("Starting monthly Fc versus u* plots")
+    try:
+        file_path = pfp_io.get_filename_dialog(file_path="../Sites",title="Choose a netCDF file")
+        if len(file_path) == 0 or not os.path.isfile(file_path):
+            return
+        # read the netCDF file
+        ds = pfp_io.NetCDFRead(file_path)
+        if ds.info["returncodes"]["value"] != 0: return
+        logger.info("Plotting Fc versus u* ...")
+        pfp_plot.plot_fcvsustar_monthly(ds)
         logger.info(" Finished plotting Fc versus u*")
         logger.info("")
     except Exception:

--- a/scripts/pfp_top_level.py
+++ b/scripts/pfp_top_level.py
@@ -438,7 +438,11 @@ def do_run_l2(cfg):
             logger.error("File "+in_filename[1]+" not found")
             return
         ds1 = pfp_io.NetCDFRead(in_filepath)
-        if ds1.info["returncodes"]["value"] != 0: return
+        if ds1.info["returncodes"]["value"] != 0:
+            return
+        pfp_compliance.check_l2_options(cfg, ds1)
+        if ds1.info["returncodes"]["value"] != 0:
+            return
         ds2 = pfp_levels.l2qc(cfg, ds1)
         if ds2.info["returncodes"]["value"] != 0:
             logger.error("An error occurred during L2 processing")
@@ -489,7 +493,14 @@ def do_run_l3(cfg):
             logger.error("File "+in_filename[1]+" not found")
             return
         ds2 = pfp_io.NetCDFRead(in_filepath)
-        if ds2.info["returncodes"]["value"] != 0: return
+        if ds2.info["returncodes"]["value"] != 0:
+            return
+        if "Options" not in cfg:
+            cfg["Options"]={}
+        cfg["Options"]["call_mode"] = "interactive"
+        pfp_compliance.check_l3_options(cfg, ds2)
+        if ds2.info["returncodes"]["value"] != 0:
+            return
         ds3 = pfp_levels.l3qc(cfg, ds2)
         if ds3.info["returncodes"]["value"] != 0:
             logger.error("An error occurred during L3 processing")

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -1755,9 +1755,11 @@ def Fco2_WPL(cf, ds, CO2_in="CO2", Fco2_in="Fco2"):
 
         Accepts meteorological constants or variables
         """
+    irga_type = str(ds.root["Attributes"]["irga_type"])
     opt = pfp_utils.get_keyvaluefromcf(cf, ["Options"], "ApplyWPL", default="Yes")
     if (opt.lower() == "no"):
-        logger.warning(" WPL correction for Fco2 disabled in control file")
+        msg = " WPL correction for Fco2 disabled in control file (" + irga_type + ")"
+        logger.warning(msg)
         return 0
     irga_type = str(ds.root["Attributes"]["irga_type"])
     msg = " Applying WPL correction to Fco2 (IRGA type is " + irga_type + ")"
@@ -1822,9 +1824,11 @@ def Fe_WPL(cf, ds):
 
         Accepts meteorological constants or variables
         """
+    irga_type = str(ds.root["Attributes"]["irga_type"])
     opt = pfp_utils.get_keyvaluefromcf(cf, ["Options"], "ApplyWPL", default="Yes")
     if (opt.lower() == "no"):
-        logger.warning(" WPL correction for Fco2 disabled in control file")
+        msg = " WPL correction for Fe disabled in control file (" + irga_type + ")"
+        logger.warning(msg)
         return 0
     irga_type = str(ds.root["Attributes"]["irga_type"])
     msg = " Applying WPL correction to Fe (IRGA type is " + irga_type + ")"

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -992,7 +992,8 @@ def CoordRotation2D(cf, ds, info):
         vw = UyUz["Data"]*ct*ce - UxUz["Data"]*ct*se - UxUy["Data"]*st*(ce*ce-se*se) + \
              UxUx["Data"]*st*ce*se - UyUy["Data"]*st*ce*se
     else:
-        logger.info(" 2D coordinate rotation disabled, using unrotated components and covariances")
+        msg = " 2D coordinate rotation disabled, using unrotated components and covariances"
+        logger.warning(msg)
         # dummy series for rotation angles
         theta = numpy.zeros(nRecs)
         eta = numpy.zeros(nRecs)

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -2422,11 +2422,14 @@ def MassmanStandard(cf, ds, Ta_in='Ta', AH_in='AH', ps_in='ps', u_in="U_SONIC_Av
     # get some instrument specific constants
     sonic_type = str(ds.root["Attributes"]["sonic_type"])
     irga_type = str(ds.root["Attributes"]["irga_type"])
-    lwVert = c.dims[sonic_type]["lwVert"]
-    lwHor = c.dims[sonic_type]["lwHor"]
-    lTv = c.dims[sonic_type]["lTv"]
-    dIRGA = c.dims[irga_type]["dIRGA"]
-    lIRGA = c.dims[irga_type]["lIRGA"]
+    lwVert = c.instruments["sonics"][sonic_type]["lwVert"]
+    lwHor = c.instruments["sonics"][sonic_type]["lwHor"]
+    lTv = c.instruments["sonics"][sonic_type]["lTv"]
+    for path_type in list(c.instruments["irgas"].keys()):
+        if irga_type in list(c.instruments["irgas"][path_type].keys()):
+            break
+    dIRGA = c.instruments["irgas"][path_type][irga_type]["dIRGA"]
+    lIRGA = c.instruments["irgas"][path_type][irga_type]["lIRGA"]
     Ta = pfp_utils.GetVariable(ds, Ta_in)
     AH = pfp_utils.GetVariable(ds, AH_in)
     ps = pfp_utils.GetVariable(ds, ps_in)

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -1755,24 +1755,11 @@ def Fco2_WPL(cf, ds, CO2_in="CO2", Fco2_in="Fco2"):
 
         Accepts meteorological constants or variables
         """
-    #if "DisableWPL" in cf["Options"]:
-        #if cf["Options"].as_bool("DisableWPL"):
-            #logger.warning(" WPL correction for Fco2 disabled in control file")
-            #return 0
-    closed_path_irgas = ["Li-7200", "Li-7200RS", "EC155"]
-    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)", "Li-7500A (>=V6.5)", "Li-7500RS",
-                       "EC150", "IRGASON"]
+    opt = pfp_utils.get_keyvaluefromcf(cf, ["Options"], "ApplyWPL", default="Yes")
+    if (opt.lower() == "no"):
+        logger.warning(" WPL correction for Fco2 disabled in control file")
+        return 0
     irga_type = str(ds.root["Attributes"]["irga_type"])
-    opt = pfp_utils.get_keyvaluefromcf(cf, ["Options"], "DisableWPL", default="No")
-    if ((opt.lower() == "no" and irga_type in open_path_irgas) or
-        (opt.lower() == "yes" and irga_type in closed_path_irgas)):
-        pass
-    else:
-        msg = "!!!!! Wrong DisableWPL option ("+opt+") for IRGA type ("+irga_type
-        logger.error("!!!!!")
-        logger.error(msg)
-        logger.error("!!!!!")
-        raise RuntimeError(msg)
     msg = " Applying WPL correction to Fco2 (IRGA type is " + irga_type + ")"
     logger.info(msg)
     descr_level = "description_" + ds.root["Attributes"]["processing_level"]
@@ -1835,11 +1822,13 @@ def Fe_WPL(cf, ds):
 
         Accepts meteorological constants or variables
         """
-    if "DisableWPL" in cf["Options"]:
-        if cf["Options"].as_bool("DisableWPL"):
-            logger.warning(" WPL correction for Fe disabled in control file")
-            return 0
-    logger.info(" Applying WPL correction to Fe")
+    opt = pfp_utils.get_keyvaluefromcf(cf, ["Options"], "ApplyWPL", default="Yes")
+    if (opt.lower() == "no"):
+        logger.warning(" WPL correction for Fco2 disabled in control file")
+        return 0
+    irga_type = str(ds.root["Attributes"]["irga_type"])
+    msg = " Applying WPL correction to Fe (IRGA type is " + irga_type + ")"
+    logger.info(msg)
     descr_level = "description_" + ds.root["Attributes"]["processing_level"]
     Fe = pfp_utils.GetVariable(ds, "Fe")
     Fh = pfp_utils.GetVariable(ds, "Fh")

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -1755,11 +1755,26 @@ def Fco2_WPL(cf, ds, CO2_in="CO2", Fco2_in="Fco2"):
 
         Accepts meteorological constants or variables
         """
-    if "DisableFco2WPL" in cf["Options"]:
-        if cf["Options"].as_bool("DisableFco2WPL"):
-            logger.warning(" WPL correction for Fco2 disabled in control file")
-            return 0
-    logger.info(" Applying WPL correction to Fco2")
+    #if "DisableWPL" in cf["Options"]:
+        #if cf["Options"].as_bool("DisableWPL"):
+            #logger.warning(" WPL correction for Fco2 disabled in control file")
+            #return 0
+    closed_path_irgas = ["Li-7200", "Li-7200RS", "EC155"]
+    open_path_irgas = ["Li-7500", "Li-7500A", "Li-7500A (<V6.5)", "Li-7500A (>=V6.5)", "Li-7500RS",
+                       "EC150", "IRGASON"]
+    irga_type = str(ds.root["Attributes"]["irga_type"])
+    opt = pfp_utils.get_keyvaluefromcf(cf, ["Options"], "DisableWPL", default="No")
+    if ((opt.lower() == "no" and irga_type in open_path_irgas) or
+        (opt.lower() == "yes" and irga_type in closed_path_irgas)):
+        pass
+    else:
+        msg = "!!!!! Wrong DisableWPL option ("+opt+") for IRGA type ("+irga_type
+        logger.error("!!!!!")
+        logger.error(msg)
+        logger.error("!!!!!")
+        raise RuntimeError(msg)
+    msg = " Applying WPL correction to Fco2 (IRGA type is " + irga_type + ")"
+    logger.info(msg)
     descr_level = "description_" + ds.root["Attributes"]["processing_level"]
     Fco2 = pfp_utils.GetVariable(ds, Fco2_in)
     Fh = pfp_utils.GetVariable(ds, "Fh")
@@ -1820,8 +1835,8 @@ def Fe_WPL(cf, ds):
 
         Accepts meteorological constants or variables
         """
-    if "DisableFeWPL" in cf["Options"]:
-        if cf["Options"].as_bool("DisableFeWPL"):
+    if "DisableWPL" in cf["Options"]:
+        if cf["Options"].as_bool("DisableWPL"):
             logger.warning(" WPL correction for Fe disabled in control file")
             return 0
     logger.info(" Applying WPL correction to Fe")


### PR DESCRIPTION
Quite a lot of work for this new version:
1) Improved handling of IRGA type to make it more intuitive and harder to choose the wrong processing options.
2) The 'instrument' variable attribute for a range of variables associated with the sonic and the IRGA is now checked against a list of known instruments.  The instrument type must be known and must be the same for all variables.
3) Duplicate variables in the L1 control file are now flagged as a warning to the user.
4) Fco2 vs u* plotting Y axis limits set to maximum and minimum of error bar lengths.
5) General cleanup of L3 Options section
6) Moved IRGA and sonic path lengths to dictionary in constants.py.
7) Added the ability to ignore error messages at L3 to allow disabling of WPL etc when comparing PyFluxPro with EddyPro.
8) Changed storage variable name from Fco2_single etc to Sco2_single
9) Window and step size for calculating E0 now read from L6 control file.
All of the above motivated by Tim and Cacilia's experiences processing the Warra data where PFP allowed the WPL correction to be applied to data from a closed-path IRGA.
