### PR TITLE
Fix use of ds.returncodes, trap missing ERUsingLloydTaylor and missing ERUsingLasslop in l6_info.

### DIFF
--- a/scripts/pfp_gf.py
+++ b/scripts/pfp_gf.py
@@ -41,14 +41,14 @@ def CheckL5Drivers(ds, l5_info):
     if len(drivers_with_missing) == 0:
         msg = "  No missing data found in drivers"
         logger.info(msg)
-        ds.returncodes = {"value": 0, "message": msg}
+        ds.info["returncodes"] = {"value": 0, "message": msg}
     else:
         dwm = ",".join(drivers_with_missing)
         msg = " Drivers " + dwm + " have missing data, aborting L5 ..."
         logger.error("!!!!!")
         logger.error(msg)
         logger.error("!!!!!")
-        ds.returncodes = {"value": 1, "message": msg}
+        ds.info["returncodes"] = {"value": 1, "message": msg}
     return
 
 def CheckGapLengths(cf, ds, l5_info):
@@ -165,14 +165,14 @@ def CheckL5Targets(ds, l5_info):
     if len(series_with_missing_data) == 0:
         msg = "  No missing data found in targets"
         logger.info(msg)
-        ds.returncodes = {"value": 0, "message": msg}
+        ds.info["returncodes"] = {"value": 0, "message": msg}
     else:
         s = ",".join(series_with_missing_data)
         msg = " Targets " + s + " contain missing data, aborting L5 ..."
         logger.error("!!!!!")
         logger.error(msg)
         logger.error("!!!!!")
-        ds.returncodes = {"value": 1, "message": msg}
+        ds.info["returncodes"] = {"value": 1, "message": msg}
     return
 
 def ParseL4ControlFile(cf, ds):

--- a/scripts/pfp_gfALT.py
+++ b/scripts/pfp_gfALT.py
@@ -241,7 +241,7 @@ def gfalternate_done(alt_gui):
     alt_gui.close()
     # write Excel spreadsheet with fit statistics
     pfp_io.xl_write_AlternateStats(alt_gui.ds4, alt_gui.l4_info)
-    # put the return code into ds.returncodes
+    # put the return code into ds.info["returncodes"]
     alt_gui.ds4.info["returncodes"]["message"] = "normal"
 
 def gfalternate_getalternatevaratmaxr(ds_tower, ds_alternate, l4a, mode="verbose"):
@@ -1060,7 +1060,7 @@ def gfalternate_plotcoveragelines(ds_tower, l4_info, called_by):
 
 def gfalternate_quit(alt_gui):
     """ Quit the GapFillFromAlternate GUI."""
-    # put the return code into ds.returncodes
+    # put the return code into ds.info["returncodes"]
     alt_gui.ds4.info["returncodes"]["message"] = "quit"
     alt_gui.ds4.info["returncodes"]["value"] = 1
     # destroy the alternate GUI

--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -673,7 +673,7 @@ def gfSOLO_qcchecks(cfg, dsa, dsb):
 
 def gfSOLO_quit(solo_gui):
     """ Quit the SOLO GUI."""
-    # put the return code into ds.returncodes
+    # put the return code into ds.info["returncodes"]
     solo_gui.ds.info["returncodes"]["message"] = "quit"
     solo_gui.ds.info["returncodes"]["value"] = 1
     # destroy the GUI

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -351,7 +351,7 @@ def csv_read_series(cf):
     s = os.stat(info["csv_filename"])
     t = time.localtime(s.st_mtime)
     ds.root["Attributes"]['csv_moddatetime'] = str(datetime.datetime(t[0],t[1],t[2],t[3],t[4],t[5]))
-    ds.returncodes = {"value":0,"message":"OK"}
+    ds.info["returncodes"] = {"value":0,"message":"OK"}
     return ds
 
 def DataFrameToDataStructure(df, l1_info):

--- a/scripts/pfp_levels.py
+++ b/scripts/pfp_levels.py
@@ -358,27 +358,35 @@ def l6qc(main_gui, cf, ds5):
         msg = " Error using SOLO to estimate ER"
         logger.error(msg)
     # estimate ER using Lloyd-Taylor
-    try:
-        # open the Excel file for writing all outputs
-        xl_name = l6_info["ERUsingLloydTaylor"]["info"]["data_file_path"]
-        xl_writer = pandas.ExcelWriter(xl_name, engine = "xlsxwriter")
-        pfp_rp.ERUsingLloydTaylor(ds6, l6_info, xl_writer)
-        xl_writer.close()
-    except RuntimeError:
-        xl_writer.close()
-        msg = " Error using Lloyd-Taylor to estimate ER"
-        logger.error(msg)
+    if "ERUsingLloydTaylor" in list(l6_info.keys()):
+        try:
+            # open the Excel file for writing all outputs
+            xl_name = l6_info["ERUsingLloydTaylor"]["info"]["data_file_path"]
+            xl_writer = pandas.ExcelWriter(xl_name, engine = "xlsxwriter")
+            pfp_rp.ERUsingLloydTaylor(ds6, l6_info, xl_writer)
+            xl_writer.close()
+        except RuntimeError:
+            xl_writer.close()
+            msg = " Error using Lloyd-Taylor to estimate ER"
+            logger.error(msg)
+    else:
+        msg = "The Lloyd-Taylor ER method is disabled in the control file"
+        logger.warning(msg)
     # estimate ER using Lasslop et al
-    try:
-        # open the Excel file for writing all outputs
-        xl_name = l6_info["ERUsingLasslop"]["info"]["data_file_path"]
-        xl_writer = pandas.ExcelWriter(xl_name, engine = "xlsxwriter")
-        pfp_rp.ERUsingLasslop(ds6, l6_info, xl_writer)
-        xl_writer.close()
-    except RuntimeError:
-        xl_writer.close()
-        msg = " Error using Lasslop et al to estimate ER"
-        logger.error(msg)
+    if "ERUsingLasslop" in list(l6_info.keys()):
+        try:
+            # open the Excel file for writing all outputs
+            xl_name = l6_info["ERUsingLasslop"]["info"]["data_file_path"]
+            xl_writer = pandas.ExcelWriter(xl_name, engine = "xlsxwriter")
+            pfp_rp.ERUsingLasslop(ds6, l6_info, xl_writer)
+            xl_writer.close()
+        except RuntimeError:
+            xl_writer.close()
+            msg = " Error using Lasslop et al to estimate ER"
+            logger.error(msg)
+    else:
+        msg = "The Lasslop ER method is disabled in the control file"
+        logger.warning(msg)
     # merge the estimates of ER with the observations
     pfp_ts.MergeSeriesUsingDict(ds6, l6_info, merge_order="standard")
     # calculate NEE from Fco2 and ER


### PR DESCRIPTION
Some L5 routines still used ds.returncodes instead of ds.info["returncodes"], fixed.
Trapped missing ERUsingLloydTaylor and ERUsingLasslop when these methods are missing from the L6 control file.