### PR TITLE
Allow creation of AWS netCDF file from CSV using L1 processing.

### DIFF
--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -738,7 +738,7 @@ def check_l1_controlfile(cfg):
         # check IRGA and sonic instrument type
         l1_check_irga_sonic_type(cfg, messages)
         # display and messages
-        display_messages_interactive(messages)
+        display_messages_interactive(messages, mode="CloseOrIgnore")
         if len(messages["ERROR"]) > 0:
             ok = False
     except Exception:
@@ -1296,7 +1296,7 @@ def l1_check_global_forced(cfg, std, messages):
     for item in forced:
         cfg["Global"][item] = forced[item]
         msg = "Global: setting " + item + " to " + forced[item]
-        #messages["INFO"].append(msg)
+        messages["INFO"].append(msg)
     # and do the time zone
     lon = float(cfg["Global"]["longitude"])
     lat = float(cfg["Global"]["latitude"])
@@ -1484,6 +1484,12 @@ def l1_check_irga_sonic_type(cfg, messages):
     sonic_only_labels = sonic_labels + t_covars + m_covars + fh_labels + fm_labels
     # sonic and fast IRGA
     sonic_irga_labels = h2o_covars + co2_covars + fco2_labels + fh2o_labels + fe_labels
+    # all sonic or IRGA related variables
+    all_sonic_irga_labels = fast_irga_only_labels + slow_irga_only_labels + sonic_only_labels + sonic_irga_labels
+    # check to see if we have any sonic and IRGA related variables
+    if set(cfg_labels).isdisjoint(set(all_sonic_irga_labels)):
+        # no sonic or IRGA variables in control file so skip checks
+        return
     # call the check routines
     l1_check_irga_only(cfg, fast_irga_only_labels, messages)
     l1_check_irga_only(cfg, slow_irga_only_labels, messages)


### PR DESCRIPTION
Generalise ability to create netCDF file from CSV or Excel file.  Use case is to generate a netCDF file of AWS data from a CSV file using L1 processing of PFP.  Required:
1) do sonic and IRGA instrument type checks only if variables associated with sonic and IRGA are in control file.
2) timestamp must now be in the first column of file but detection of timestamp type is more robust ('datetime64[ns]', '<M8[ns]', '>M8[ns]' and 'object' are now handled correctly).