### PR TITLE
Fix timestamp detection l1

### DIFF
--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -1,5 +1,7 @@
 version_name = "PyFluxPro"
-version_number = "V3.4.11"
+version_number = "V3.4.12"
+# V3.4.12 - March 2023
+#         - improve detection of timestamp when reading Excel workbook
 # V3.4.11 - January 2023
 #         - add 'SeriesToKeep' to [Options] at concatenate
 #           - allows user to specify the variable that will be written to the

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -738,41 +738,6 @@ def ReadExcelWorkbook(l1_info):
     pfp_log.debug_function_leave(inspect.currentframe().f_code.co_name)
     return dfs
 
-#def read_excel_workbook_get_timestamp(dfs, df_name, l1_info):
-    #""" Get the timestamp column name."""
-    #df = dfs[df_name]
-    #dt_columns = [c for c in df.columns if pandas.api.types.is_datetime64_dtype(df[c])]
-    #if len(dt_columns) > 0:
-        #timestamp =  df.columns[dt_columns[0]]
-    #else:
-        ## can't find a timestamp on this sheet
-        #msg = " Unable to find a timestamp for " + df_name + ", deleting ..."
-        #logger.error(msg)
-        #del dfs[df_name]
-        #del l1_info["read_excel"]["xl_sheets"][df_name]
-        #timestamp = None
-
-    ### is_datetime64_dtype should trap '<M8[ns]' and '>M8[ns]' as well
-    ### as datetim64[ns]
-    ##if pandas.api.types.is_datetime64_dtype(df[df.columns[0]]):
-        ##timestamp = df.columns[0]
-    ### pandas sometimes returns a column that can be interpreted as
-    ### datetime as dtype object
-    ##elif pandas.api.types.is_object_dtype(df[df.columns[0]]):
-        ### convert dtype object to datetime64[ns]
-        ##df[df.columns[0]] = pandas.to_datetime(df[df.columns[0]],
-                                               ##infer_datetime_format=True,
-                                               ##errors='coerce')
-        ##timestamp = df.columns[0]
-    ##else:
-        ### can't interpret column 0 as a datetime so delete sheet
-        ##msg = " Unable to convert column " + df.columns[0] + " to a time stamp"
-        ##logger.error(msg)
-        ##del dfs[df_name]
-        ##del l1_info["read_excel"]["xl_sheets"][df_name]
-        ##timestamp = None
-    #return timestamp
-
 def read_excel_workbook_get_timestamp(dfs, df_name, l1_info):
     df = dfs[df_name]
     got_timestamp = False
@@ -783,7 +748,7 @@ def read_excel_workbook_get_timestamp(dfs, df_name, l1_info):
             more_than_one = True
         for dt_column in dt_columns:
             try:
-                s = pandas.to_datetime(df[dt_column])
+                df[dt_column] = pandas.to_datetime(df[dt_column])
                 timestamp = dt_column
                 got_timestamp = True
                 break
@@ -795,7 +760,7 @@ def read_excel_workbook_get_timestamp(dfs, df_name, l1_info):
             more_than_one = True
         for obj_column in obj_columns:
             try:
-                s = pandas.to_datetime(df[obj_column])
+                df[obj_column] = pandas.to_datetime(df[obj_column])
                 timestamp = obj_column
                 got_timestamp = True
                 break

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -17,6 +17,7 @@ import dateutil
 import netCDF4
 import numpy
 import pandas
+from pandas.errors import ParserError
 import xlwt
 import xlsxwriter
 from PyQt5 import QtWidgets
@@ -737,24 +738,75 @@ def ReadExcelWorkbook(l1_info):
     pfp_log.debug_function_leave(inspect.currentframe().f_code.co_name)
     return dfs
 
+#def read_excel_workbook_get_timestamp(dfs, df_name, l1_info):
+    #""" Get the timestamp column name."""
+    #df = dfs[df_name]
+    #dt_columns = [c for c in df.columns if pandas.api.types.is_datetime64_dtype(df[c])]
+    #if len(dt_columns) > 0:
+        #timestamp =  df.columns[dt_columns[0]]
+    #else:
+        ## can't find a timestamp on this sheet
+        #msg = " Unable to find a timestamp for " + df_name + ", deleting ..."
+        #logger.error(msg)
+        #del dfs[df_name]
+        #del l1_info["read_excel"]["xl_sheets"][df_name]
+        #timestamp = None
+
+    ### is_datetime64_dtype should trap '<M8[ns]' and '>M8[ns]' as well
+    ### as datetim64[ns]
+    ##if pandas.api.types.is_datetime64_dtype(df[df.columns[0]]):
+        ##timestamp = df.columns[0]
+    ### pandas sometimes returns a column that can be interpreted as
+    ### datetime as dtype object
+    ##elif pandas.api.types.is_object_dtype(df[df.columns[0]]):
+        ### convert dtype object to datetime64[ns]
+        ##df[df.columns[0]] = pandas.to_datetime(df[df.columns[0]],
+                                               ##infer_datetime_format=True,
+                                               ##errors='coerce')
+        ##timestamp = df.columns[0]
+    ##else:
+        ### can't interpret column 0 as a datetime so delete sheet
+        ##msg = " Unable to convert column " + df.columns[0] + " to a time stamp"
+        ##logger.error(msg)
+        ##del dfs[df_name]
+        ##del l1_info["read_excel"]["xl_sheets"][df_name]
+        ##timestamp = None
+    #return timestamp
+
 def read_excel_workbook_get_timestamp(dfs, df_name, l1_info):
-    """ Get the timestamp column name."""
     df = dfs[df_name]
-    # is_datetime64_dtype should trap '<M8[ns]' and '>M8[ns]' as well
-    # as datetim64[ns]
-    if pandas.api.types.is_datetime64_dtype(df[df.columns[0]]):
-        timestamp = df.columns[0]
-    # pandas sometimes returns a column that can be interpreted as
-    # datetime as dtype object
-    elif pandas.api.types.is_object_dtype(df[df.columns[0]]):
-        # convert dtype object to datetime64[ns]
-        df[df.columns[0]] = pandas.to_datetime(df[df.columns[0]],
-                                               infer_datetime_format=True,
-                                               errors='coerce')
-        timestamp = df.columns[0]
+    got_timestamp = False
+    more_than_one = False
+    if not got_timestamp:
+        dt_columns = [c for c in df.columns if pandas.api.types.is_datetime64_dtype(df[c])]
+        if len(dt_columns) > 1:
+            more_than_one = True
+        for dt_column in dt_columns:
+            try:
+                s = pandas.to_datetime(df[dt_column])
+                timestamp = dt_column
+                got_timestamp = True
+                break
+            except (ParserError, ValueError):
+                pass
+    if not got_timestamp:
+        obj_columns = [c for c in df.columns[df.dtypes=='object']]
+        if len(obj_columns) > 1:
+            more_than_one = True
+        for obj_column in obj_columns:
+            try:
+                s = pandas.to_datetime(df[obj_column])
+                timestamp = obj_column
+                got_timestamp = True
+                break
+            except (ParserError,ValueError):
+                pass
+    if got_timestamp:
+        if more_than_one:
+            msg = " Using " + timestamp + " as the timestamp for sheet " + df_name
+            logger.info(msg)
     else:
-        # can't interpret column 0 as a datetime so delete sheet
-        msg = " Unable to convert column " + df.columns[0] + " to a time stamp"
+        msg = " Unable to find a timestamp for " + df_name + ", deleting ..."
         logger.error(msg)
         del dfs[df_name]
         del l1_info["read_excel"]["xl_sheets"][df_name]


### PR DESCRIPTION
Improve detection of datetime columns in Excel workbook.  The order of detection is:

1. Get all columns that pandas returns as datetime64 and chose the first column where all rows can be converted to a datetime.
2. If the first check doesn't provide a timestamp column, then repeat the process using columns returned by pandas as object.
3. Return None if neither of these checks detects a timestamp.
