### PR TITLE
Fix numpy and pandas deprecated methods, create plots directory.

### DIFF
--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -1,5 +1,7 @@
 version_name = "PyFluxPro"
-version_number = "V3.4.12"
+version_number = "V3.4.13"
+# V3.4.13 - May 2023
+#         - remove numpy dtypes e.g. dtype=numpy.int becomes dtype=int
 # V3.4.12 - March 2023
 #         - improve detection of timestamp when reading Excel workbook
 # V3.4.11 - January 2023

--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -141,7 +141,7 @@ def ApplyTurbulenceFilter(cf, ds, l5_info, ustar_threshold=None):
             # ... but only if the ustar data is not masked
             c2 = (numpy.ma.getmaskarray(ustar) == False)
             idx = numpy.where(c1 & c2)[0]
-            indicators["final"]["Data"][idx] = numpy.int(1)
+            indicators["final"]["Data"][idx] = int(1)
             indicators["final"]["Attr"].update(indicators["day"]["Attr"])
         else:
             msg = " u* filter applied to day time data (FluxNet method)"
@@ -646,7 +646,7 @@ def do_EPQCFlagCheck(cf, ds, section, series, code=9):
             idx = numpy.where(bool_array == True)[0]
             flag[idx] = numpy.int32(1)
     idx = numpy.where(flag == 1)[0]
-    variable["Data"][idx] = numpy.float(c.missing_value)
+    variable["Data"][idx] = float(c.missing_value)
     variable["Flag"][idx] = numpy.int32(9)
     pfp_utils.CreateVariable(ds, variable)
     return

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -2154,8 +2154,9 @@ def l2_check_files(cfg, messages):
             if os.path.isdir(plot_path):
                 pass
             else:
-                msg = "Files: " + plot_path + " is not a directory"
-                messages["ERROR"].append(msg)
+                msg = "Files: " + plot_path + " doesn't exist, creating ..."
+                messages["INFO"].append(msg)
+                os.mkdir(plot_path)
         else:
             msg = "Files: 'plot_path' not in section"
             messages["ERROR"].append(msg)
@@ -2797,8 +2798,9 @@ def l6_check_files(cfg, messages):
             if os.path.isdir(plot_path):
                 pass
             else:
-                msg = "Files: " + plot_path + " is not a directory"
-                messages["ERROR"].append(msg)
+                msg = "Files: " + plot_path + " doesn't exist, creating ..."
+                messages["INFO"].append(msg)
+                os.mkdir(plot_path)
         else:
             msg = "Files: 'plot_path' not in section"
             messages["ERROR"].append(msg)

--- a/scripts/pfp_cpd_barr.py
+++ b/scripts/pfp_cpd_barr.py
@@ -145,7 +145,7 @@ def xl_write_cpd(cpd_full_path, ustar_results):
         df_by_years = pandas.DataFrame.from_dict(by_years[year])
         df_by_years.index.names = ["Bootstraps"]
         df_by_years.to_excel(xlwriter, sheet_name=str(year))
-    xlwriter.save()
+    xlwriter.close()
     return
 
 def cpdBootstrapUStarTh4Season20100901(t, NEE, uStar, T, fNight, fPlot, cSiteYr, nBoot, pb):
@@ -783,7 +783,7 @@ def cpdBin(x, y, dx, nPerBin):
         # into bins with nPerBin points in each bin.
         iYaN = numpy.where(~numpy.isnan(x + y) == True)[0]
         nYaN = len(iYaN)
-        nBins = numpy.floor(nYaN / nPerBin).astype(numpy.int)
+        nBins = numpy.floor(nYaN / nPerBin).astype(int)
         mx = numpy.full(nBins, numpy.nan)
         my = numpy.full(nBins, numpy.nan)
         iprctile = numpy.arange(0, 101, (100. / float(nBins)))
@@ -803,8 +803,8 @@ def cpdBin(x, y, dx, nPerBin):
     elif len(dx) == 1:
         nx = numpy.min(x)
         xx = numpy.max(x)
-        nx = dx*numpy.floor(nx / dx).astype(numpy.int)
-        xx = dx*numpy.ceil(xx / dx).astype(numpy.int)
+        nx = dx*numpy.floor(nx / dx).astype(int)
+        xx = dx*numpy.ceil(xx / dx).astype(int)
         mx = numpy.full(len(numpy.arange(nx, xx, dx)), numpy.nan)
         my = numpy.full(len(numpy.arange(nx, xx, dx)), numpy.nan)
         for jx in numpy.arange(nx, xx, dx):

--- a/scripts/pfp_cpd_mchugh.py
+++ b/scripts/pfp_cpd_mchugh.py
@@ -268,7 +268,7 @@ def cpd_mchugh_main(cf):
         #output_stats_df.to_csv(os.path.join(d['results_output_path'], 'annual_statistics.csv'))
     xlsheet = "Annual"
     output_stats_df.to_excel(xlwriter,sheet_name=xlsheet)
-    xlwriter.save()
+    xlwriter.close()
     # close any open plot windows if we are doing batch processing
     #if d["call_mode"]!="interactive": plt.close('all')
 

--- a/scripts/pfp_cpd_mcnew.py
+++ b/scripts/pfp_cpd_mcnew.py
@@ -748,7 +748,7 @@ def _write_to_file(data_dict, write_to_file):
                  .to_excel(xlwriter, sheet_name=str(year), index=None)
                  )
             continue
-    xlwriter.save()
+    xlwriter.close()
 #------------------------------------------------------------------------------
 
 #------------------------------------------------------------------------------

--- a/scripts/pfp_gf.py
+++ b/scripts/pfp_gf.py
@@ -1196,8 +1196,8 @@ def gfClimatology_monthly(ds, series, output, xlbook):
         xlCol = m*5 + 2
         values[:, m] = thissheet.col_values(xlCol)[2:50]
     for i in range(len(ds.root["Variables"][series]["Data"])):
-        h = numpy.int(2*Hdh[i])
-        m = numpy.int(Month[i])
+        h = int(2*Hdh[i])
+        m = int(Month[i])
         val1d[i] = values[h, m-1]
     index = numpy.where(abs(ds.root["Variables"][output]["Data"] - c.missing_value) < c.eps)[0]
     ds.root["Variables"][output]["Data"][index] = val1d[index]

--- a/scripts/pfp_mpt.py
+++ b/scripts/pfp_mpt.py
@@ -239,5 +239,5 @@ def xl_write_mpt(mpt_full_path, ustar_results):
         df_bootstraps = pandas.DataFrame.from_dict(by_years["Bootstraps"])
         df_bootstraps.index.names = ["Bootstraps"]
         df_bootstraps.to_excel(xlwriter, sheet_name=str(year), startrow=20)
-    xlwriter.save()
+    xlwriter.close()
     return

--- a/scripts/pfp_part.py
+++ b/scripts/pfp_part.py
@@ -280,9 +280,8 @@ class partition(object):
             params = params_df.loc[date]
             str_date = dt.datetime.strftime(date, '%Y-%m-%d')
             data = self.df.loc[str_date, 'TC']
-            resp_series = resp_series.append(_Lloyd_and_Taylor
-                                             (t_series = data,
-                                              Eo = params.Eo, rb = params.rb))
+            rs = _Lloyd_and_Taylor(t_series=data, rb=params.rb, Eo=params.Eo)
+            resp_series = pd.concat([resp_series, rs])
         return resp_series
     #--------------------------------------------------------------------------
 

--- a/scripts/pfp_rp.py
+++ b/scripts/pfp_rp.py
@@ -297,7 +297,7 @@ def EcoResp(ds, l6_info, called_by, xl_writer):
         pfp_utils.CreateVariable(ds, ER)
         # Write to excel
         params_df.to_excel(xl_writer, output)
-        xl_writer.save()
+        xl_writer.close()
         # Do plotting
         startdate = str(ds.root["Variables"]["DateTime"]["Data"][0])
         enddate = str(ds.root["Variables"]["DateTime"]["Data"][-1])
@@ -395,7 +395,7 @@ def GetERFromFco2(ds, l6_info):
     notok = numpy.ones(nrecs)
     for flag_value in [0, 10]:
         idx = numpy.where(Fco2["Flag"] == flag_value)[0]
-        notok[idx] = numpy.int(0)
+        notok[idx] = int(0)
     Fco2["Data"] = numpy.ma.masked_where((notok == 1), Fco2["Data"])
     ER["Flag"] = numpy.where((notok == 1), numpy.full(nrecs, 501), numpy.zeros(nrecs))
     # get the indicator series

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -2411,10 +2411,10 @@ def MassmanStandard(cf, ds, Ta_in='Ta', AH_in='AH', ps_in='ps', u_in="U_SONIC_Av
           "east_separation" in cf["Massman"]):
         # the following is the definition of lateral and longitudinal separation
         # used in EddyPro, it is not equivalent to the one used above
-        nsep = numpy.float(cf["Massman"]["north_separation"])
-        esep = numpy.float(cf["Massman"]["east_separation"])
+        nsep = float(cf["Massman"]["north_separation"])
+        esep = float(cf["Massman"]["east_separation"])
         lLat = numpy.sqrt(nsep*nsep + esep*esep)
-        lLong = numpy.float(0)
+        lLong = float(0)
     else:
         msg = " Required separation information not found in Massman section of control file"
         logger.error(msg)
@@ -2735,8 +2735,8 @@ def MergeSeries(cf,ds,series,okflags=[0,10,20,30,40,50,60],convert_units=False,s
                         logger.error(msg)
                         continue
                 SeriesNameString = SeriesNameString + ", " + secondary_series
-                p_idx = numpy.zeros(p_recs, dtype=numpy.int)
-                s_idx = numpy.zeros(s_recs, dtype=numpy.int)
+                p_idx = numpy.zeros(p_recs, dtype=int)
+                s_idx = numpy.zeros(s_recs, dtype=int)
                 for okflag in okflags:
                     # index of acceptable primary values
                     index = numpy.where(primary["Flag"] == okflag)[0]
@@ -2853,8 +2853,8 @@ def ReplaceWhenDiffExceedsRange(DateTime,Destination,Primary,Secondary,RList):
 def savitzky_golay(y, window_size, order, deriv=0):
     ''' Apply Savitsky-Golay low-pass filter to data.'''
     try:
-        window_size = numpy.abs(numpy.int(window_size))
-        order = numpy.abs(numpy.int(order))
+        window_size = numpy.abs(int(window_size))
+        order = numpy.abs(int(order))
     except ValueError:
         raise ValueError("window_size and order have to be of type int")
     if window_size % 2 != 1 or window_size < 1:

--- a/scripts/pfp_utils.py
+++ b/scripts/pfp_utils.py
@@ -1904,125 +1904,6 @@ def GetSeries(ds, label, group="root", out_type="ma"):
         data = numpy.ma.masked_values(data, c.missing_value)
     return data, flag, attr
 
-#def GetSeries(ds, ThisOne, si=0, ei=-1, mode="truncate"):
-    #""" Returns the data, QC flag and attributes of a series from the data structure."""
-    ## number of records
-    #nRecs = int(ds.root["Attributes"]["nc_nrecs"])
-    #ts = int(ds.root["Attributes"]["time_step"])
-
-    ## check the series requested is in the data structure
-    #if ThisOne in list(ds.root["Variables"].keys()):
-        ## series is in the data structure
-        #if isinstance(ds.root["Variables"][ThisOne]["Data"], list):
-            ## return a list if the series is a list
-            #Series = list(ds.root["Variables"][ThisOne]["Data"])
-        #elif isinstance(ds.root["Variables"][ThisOne]["Data"], numpy.ndarray):
-            ## return a numpy array if series is an array
-            #Series = ds.root["Variables"][ThisOne]["Data"].copy()
-        ## now get the QC flag
-        #if 'Flag' in list(ds.root["Variables"][ThisOne].keys()):
-            ## return the QC flag if it exists
-            #Flag = ds.root["Variables"][ThisOne]["Flag"].copy()
-        #else:
-            ## create a QC flag if one does not exist
-            #Flag = numpy.zeros(nRecs, dtype=numpy.int32)
-        ## now get the attribute dictionary
-        #if "Attr" in list(ds.root["Variables"][ThisOne].keys()):
-            #Attr = copy.deepcopy(ds.root["Variables"][ThisOne]["Attr"])
-        #else:
-            #Attr = make_attribute_dictionary()
-    #else:
-        ## tell the user we can't find the series
-        #msg = " GetSeries: " + ThisOne + " not found, creating empty series ..."
-        #logger.warning(msg)
-        #Series,Flag,Attr = MakeEmptySeries(ds,ThisOne)
-
-    ## tidy up
-    #if ei==-1: ei = nRecs - 1
-    #if mode=="truncate":
-        ## truncate to the requested start and end indices
-        #si = max(0,si)                  # clip start index at 0
-        #ei = min(nRecs,ei)              # clip end index to nRecs
-        #Series = Series[si:ei+1]        # truncate the data
-        #Flag = Flag[si:ei+1]            # truncate the QC flag
-    #elif mode=="pad":
-        ## we treat the DateTime series differently and pad with real datetimes
-        #if ThisOne == "DateTime":
-            #dts = datetime.timedelta(minutes=ts)
-            ##start_date = datetime.datetime(Series[0].year, Series[0].month, Series[0].day, 0, 0, 0)
-            #start_date = datetime.datetime((Series[0]-dts).year,
-                                           #(Series[0]-dts).month,
-                                           #(Series[0]-dts).day, 0, 0, 0)
-            #start_date = start_date + dts
-            #end_date = datetime.datetime(Series[-1].year, Series[-1].month, Series[-1].day, 0, 0, 0)
-            #if not ((Series[-1].hour == 0) and
-                    #(Series[-1].minute == 0) and
-                    #(Series[-1].second == 0)):
-                #end_date = end_date + datetime.timedelta(days=1)
-            #data_start = numpy.array([dt for dt in perdelta(start_date, Series[0]-dts, dts)])
-            #flag_start = numpy.zeros(abs(si),dtype=numpy.int32)
-            #data_end = numpy.array([dt for dt in perdelta(Series[-1]+dts, end_date, dts)])
-            #flag_end = numpy.zeros((ei-(nRecs-1)),dtype=numpy.int32)
-        #else:
-            #data_start = float(c.missing_value)*numpy.ones(abs(si),dtype=numpy.float64)
-            #flag_start = numpy.ones(abs(si),dtype=numpy.int32)
-            #data_end = float(c.missing_value)*numpy.ones((ei-(nRecs-1)),dtype=numpy.float64)
-            #flag_end = numpy.ones((ei-(nRecs-1)),dtype=numpy.int32)
-        ## pad with missing data at the start and/or the end of the series
-        #if si<0 and ei>nRecs-1:
-            ## pad at the start
-            #Series = numpy.append(data_start, Series)
-            #Flag = numpy.append(flag_start, Flag)
-            ## pad at the end
-            #Series = numpy.append(Series, data_end)
-            #Flag = numpy.append(Flag, flag_end)
-        #elif si<0 and ei<=nRecs-1:
-            ## pad at the start, truncate the end
-            #Series = numpy.append(data_start, Series[:ei+1])
-            #Flag = numpy.append(flag_start, Flag[:ei+1])
-        #elif si>=0 and ei>nRecs-1:
-            ## truncate at the start, pad at the end
-            #Series = numpy.append(Series[si:], data_end)
-            #Flag = numpy.append(Flag[si:], flag_end)
-        #elif si>=0 and ei<=nRecs-1:
-            ## truncate at the start and end
-            #Series = Series[si:ei+1]
-            #Flag = Flag[si:ei+1]
-        #else:
-            #msg = 'GetSeries: unrecognised combination of si ('+str(si)+') and ei ('+str(ei)+')'
-            #raise ValueError(msg)
-    #elif mode=="mirror":
-        ## reflect data about end boundaries if si or ei are out of bounds
-        #if si<0 and ei>nRecs-1:
-            ## mirror at the start
-            #Series = numpy.append(numpy.fliplr([Series[1:abs(si)+1]])[0],Series)
-            #Flag = numpy.append(numpy.fliplr([Flag[1:abs(si)+1]])[0],Flag)
-            ## mirror at the end
-            #sim = 2*nRecs-1-ei
-            #eim = nRecs-1
-            #Series = numpy.append(Series,numpy.fliplr([Series[sim:eim]])[0])
-            #Flag = numpy.append(Flag,numpy.fliplr([Flag[sim:eim]])[0])
-        #elif si<0 and ei<=nRecs-1:
-            ## mirror at start, truncate at end
-            #Series = numpy.append(numpy.fliplr([Series[1:abs(si)+1]])[0],Series[:ei+1])
-            #Flag = numpy.append(numpy.fliplr([Flag[1:abs(si)+1]])[0],Flag[:ei+1])
-        #elif si>=0 and ei>nRecs-1:
-            ## truncate at start, mirror at end
-            #sim = 2*nRecs-1-ei
-            #eim = nRecs
-            #Series = numpy.append(Series[si:],numpy.fliplr([Series[sim:eim]])[0])
-            #Flag = numpy.append(Flag[si:],numpy.fliplr([Flag[sim:eim]])[0])
-        #elif si>=0 and ei<=nRecs-1:
-            ## truncate at the start and end
-            #Series = Series[si:ei+1]
-            #Flag = Flag[si:ei+1]
-        #else:
-            #msg = 'GetSeries: unrecognised combination of si ('+str(si)+') and ei ('+str(ei)+')'
-            #raise ValueError(msg)
-    #else:
-        #raise ValueError("GetSeries: unrecognised mode option "+str(mode))
-    #return Series, Flag, Attr
-
 def MakeEmptySeries(ds, ThisOne):
     nRecs = int(ds.root["Attributes"]["nc_nrecs"])
     Series = float(c.missing_value)*numpy.ones(nRecs, dtype=numpy.float64)
@@ -3204,7 +3085,7 @@ def SeriestoMA(Series):
     if Series.dtype == "float64":
         if not numpy.ma.isMA(Series):
             WasND = True
-            Series = numpy.ma.masked_where(abs(Series-numpy.float(c.missing_value)) < c.eps, Series)
+            Series = numpy.ma.masked_where(abs(Series-float(c.missing_value)) < c.eps, Series)
     return Series, WasND
 
 def SetUnitsInds(ds, ThisOne, units):


### PR DESCRIPTION
Methods that were deprecated in previous versions of numpy and pandas have been removed in current versions (e.g. numpy.int, xlswrite.save() etc).  Use of these in PFP has now been updated to best practice for current versions.

Also, if the plots directory is missing, it is now created.