### PR TITLE
Fix mds bug

### DIFF
--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -1,5 +1,15 @@
 version_name = "PyFluxPro"
-version_number = "V3.4.13"
+version_number = "V3.4.14"
+# V3.4.14 - June 2023
+#         - fix problem associated with MDS gap filling and data sets that start
+#           at YYYY-01-01 00:00
+#           - the MDS C code discards YYYY-01-01 00:00 so the MDS output ends
+#             up being 1 element shorter than the input data
+#         - discovered that the default behaviour of numpy.array() and numpy.ma.array()
+#           are different
+#           - numpy.array() default is copy=True
+#           - numpy.ma.array() default is copy=False
+#           - changed all calls to numpy.ma.array() to include copy=True
 # V3.4.13 - May 2023
 #         - remove numpy dtypes e.g. dtype=numpy.int becomes dtype=int
 # V3.4.12 - March 2023

--- a/scripts/pfp_gfMDS.py
+++ b/scripts/pfp_gfMDS.py
@@ -124,17 +124,9 @@ def gfMDS_get_mds_output(ds, mds_label, out_file_path, l5_info, called_by):
     # get the name for the description variable attribute
     descr_level = "description_" + str(ds.root["Attributes"]["processing_level"])
     ldt = pfp_utils.GetVariable(ds, "DateTime")
-
-    #first_date = ldt["Data"][0]
-    #last_date = ldt["Data"][-1]
-
     data_mds = numpy.genfromtxt(out_file_path, delimiter=",", names=True, autostrip=True, dtype=None)
     dt_mds = numpy.array([dateutil.parser.parse(str(dt)) for dt in data_mds["TIMESTAMP"]])
     idxa, idxb = pfp_utils.FindMatchingIndices(ldt["Data"], dt_mds)
-
-    #si_mds = pfp_utils.GetDateIndex(dt_mds, first_date)
-    #ei_mds = pfp_utils.GetDateIndex(dt_mds, last_date)
-
     # get a list of the names in the data array
     mds_output_names = list(data_mds.dtype.names)
     # strip out the timestamp and the original data
@@ -149,8 +141,10 @@ def gfMDS_get_mds_output(ds, mds_label, out_file_path, l5_info, called_by):
             data_out = numpy.ma.array(var_in["Data"], copy=True)
             data_out[idxa] = data_mds[mds_output_name][idxb]
             data_out = numpy.ma.masked_values(data_out, c.missing_value)
-            # ugly hack for datasets that start on YYYY-01-01 00:00, the MDS C code discards
+            # Ugly hack for datasets that start on YYYY-01-01 00:00, the MDS C code discards
             # these times and they are missing from the MDS output.
+            # Many thanks to Professor Shih-Chieh Chang of National Dong Hwa University, Taiwan
+            # for reporting this bug.  Problems often behave like fractals.
             if numpy.ma.is_masked(data_out[0]):
                 data_out[0] = data_out[1]
             idx = numpy.where(numpy.ma.getmaskarray(var_in["Data"]) == True)[0]

--- a/scripts/pfp_gfMDS.py
+++ b/scripts/pfp_gfMDS.py
@@ -115,6 +115,7 @@ def gfMDS_get_mds_output(ds, mds_label, out_file_path, l5_info, called_by):
     Author: PRI
     Date: May 2018
     """
+    nrecs = int(ds.root["Attributes"]["nc_nrecs"])
     # get the MDS flag value from the processing level
     processing_level = ds.root["Attributes"]["processing_level"]
     level_number = pfp_utils.strip_non_numeric(processing_level)
@@ -123,12 +124,17 @@ def gfMDS_get_mds_output(ds, mds_label, out_file_path, l5_info, called_by):
     # get the name for the description variable attribute
     descr_level = "description_" + str(ds.root["Attributes"]["processing_level"])
     ldt = pfp_utils.GetVariable(ds, "DateTime")
-    first_date = ldt["Data"][0]
-    last_date = ldt["Data"][-1]
+
+    #first_date = ldt["Data"][0]
+    #last_date = ldt["Data"][-1]
+
     data_mds = numpy.genfromtxt(out_file_path, delimiter=",", names=True, autostrip=True, dtype=None)
     dt_mds = numpy.array([dateutil.parser.parse(str(dt)) for dt in data_mds["TIMESTAMP"]])
-    si_mds = pfp_utils.GetDateIndex(dt_mds, first_date)
-    ei_mds = pfp_utils.GetDateIndex(dt_mds, last_date)
+    idxa, idxb = pfp_utils.FindMatchingIndices(ldt["Data"], dt_mds)
+
+    #si_mds = pfp_utils.GetDateIndex(dt_mds, first_date)
+    #ei_mds = pfp_utils.GetDateIndex(dt_mds, last_date)
+
     # get a list of the names in the data array
     mds_output_names = list(data_mds.dtype.names)
     # strip out the timestamp and the original data
@@ -140,30 +146,37 @@ def gfMDS_get_mds_output(ds, mds_label, out_file_path, l5_info, called_by):
         if mds_output_name == "FILLED":
             # get the gap filled target and write it to the data structure
             var_in = pfp_utils.GetVariable(ds, l5_info[called_by]["outputs"][mds_label]["target"])
-            data = data_mds[mds_output_name][si_mds:ei_mds+1]
-            idx = numpy.where((numpy.ma.getmaskarray(var_in["Data"]) == True) &
-                              (abs(data - c.missing_value) > c.eps))[0]
-            flag = numpy.array(var_in["Flag"])
+            data_out = numpy.ma.array(var_in["Data"], copy=True)
+            data_out[idxa] = data_mds[mds_output_name][idxb]
+            data_out = numpy.ma.masked_values(data_out, c.missing_value)
+            # ugly hack for datasets that start on YYYY-01-01 00:00, the MDS C code discards
+            # these times and they are missing from the MDS output.
+            if numpy.ma.is_masked(data_out[0]):
+                data_out[0] = data_out[1]
+            idx = numpy.where(numpy.ma.getmaskarray(var_in["Data"]) == True)[0]
+            flag = numpy.array(var_in["Flag"], copy=True)
             flag[idx] = numpy.int32(mds_flag_value)
             attr = copy.deepcopy(var_in["Attr"])
             pfp_utils.append_to_attribute(attr, {descr_level: "Gap filled using MDS"})
-            var_out = {"Label":mds_label, "Data":data, "Flag":flag, "Attr":attr}
+            var_out = {"Label": mds_label, "Data": data_out, "Flag": flag, "Attr": attr}
             pfp_utils.CreateVariable(ds, var_out)
         elif mds_output_name == "TIMEWINDOW":
             # make the series name for the data structure
             mds_qc_label = "MDS"+"_"+l5_info[called_by]["outputs"][mds_label]["target"]+"_"+mds_output_name
-            data = data_mds[mds_output_name][si_mds:ei_mds+1]
-            flag = numpy.zeros(len(data))
+            data_out = numpy.zeros(nrecs, dtype=float)
+            data_out[idxa] = data_mds[mds_output_name][idxb]
+            flag = numpy.zeros(nrecs, dtype=int)
             attr = {"long_name":"TIMEWINDOW from MDS gap filling for "+l5_info[called_by]["outputs"][mds_label]["target"]}
-            var_out = {"Label":mds_qc_label, "Data":data, "Flag":flag, "Attr":attr}
+            var_out = {"Label": mds_qc_label, "Data": data_out, "Flag": flag, "Attr": attr}
             pfp_utils.CreateVariable(ds, var_out)
         else:
             # make the series name for the data structure
             mds_qc_label = "MDS"+"_"+l5_info[called_by]["outputs"][mds_label]["target"]+"_"+mds_output_name
-            data = data_mds[mds_output_name][si_mds:ei_mds+1]
-            flag = numpy.zeros(len(data))
+            data_out = numpy.zeros(nrecs, dtype=float)
+            data_out[idxa] = data_mds[mds_output_name][idxb]
+            flag = numpy.zeros(nrecs, dtype=int)
             attr = {"long_name":"QC field from MDS gap filling for "+l5_info[called_by]["outputs"][mds_label]["target"]}
-            var_out = {"Label":mds_qc_label, "Data":data, "Flag":flag, "Attr":attr}
+            var_out = {"Label": mds_qc_label, "Data": data_out, "Flag": flag, "Attr": attr}
             pfp_utils.CreateVariable(ds, var_out)
     return
 
@@ -338,7 +351,7 @@ def gfMDS_plot(pd, ds, mds_label, l5_info, called_by):
     ax1 = plt.axes(rect1)
     # get the diurnal stats of the observations
     mask = numpy.ma.mask_or(obs["Data"].mask, mds["Data"].mask)
-    obs_mor = numpy.ma.array(obs["Data"], mask=mask)
+    obs_mor = numpy.ma.array(obs["Data"], mask=mask, copy=True)
     _, Hr1, Av1, _, _, _ = gf_getdiurnalstats(Hdh, obs_mor, ts)
     ax1.plot(Hr1, Av1, 'b-', label="Obs")
     # get the diurnal stats of all SOLO predictions

--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -363,14 +363,14 @@ def gfSOLO_plot(pd, ds, drivers, target, output, l5s, si=0, ei=-1):
     ax1 = plt.axes(rect1)
     # get the diurnal stats of the observations
     mask = numpy.ma.mask_or(obs["Data"].mask, mod["Data"].mask)
-    obs_mor = numpy.ma.array(obs["Data"], mask=mask)
+    obs_mor = numpy.ma.array(obs["Data"], mask=mask, copy=True)
     _, Hr1, Av1, _, _, _ = gf_getdiurnalstats(Hdh, obs_mor, ts)
     ax1.plot(Hr1, Av1, 'b-', label="Obs")
     # get the diurnal stats of all SOLO predictions
     _, Hr2, Av2, _, _, _ = gf_getdiurnalstats(Hdh, mod["Data"], ts)
     ax1.plot(Hr2, Av2, 'r-', label="SOLO(all)")
     # get the diurnal stats of SOLO predictions when the obs are present
-    mod_mor = numpy.ma.array(mod["Data"], mask=mask)
+    mod_mor = numpy.ma.array(mod["Data"], mask=mask, copy=True)
     if numpy.ma.count_masked(obs["Data"]) != 0:
         index = numpy.where(numpy.ma.getmaskarray(obs["Data"]) == False)[0]
         # get the diurnal stats of SOLO predictions when observations are present
@@ -389,7 +389,7 @@ def gfSOLO_plot(pd, ds, drivers, target, output, l5s, si=0, ei=-1):
     ax2.set_xlabel(target + '_SOLO')
     # plot the best fit line
     coefs = numpy.ma.polyfit(numpy.ma.copy(mod["Data"]), numpy.ma.copy(obs["Data"]), 1)
-    xfit = numpy.ma.array([numpy.ma.min(mod["Data"]), numpy.ma.max(mod["Data"])])
+    xfit = numpy.ma.array([numpy.ma.min(mod["Data"]), numpy.ma.max(mod["Data"])], copy=True)
     yfit = numpy.polyval(coefs, xfit)
     r = numpy.ma.corrcoef(mod["Data"], obs["Data"])
     ax2.plot(xfit, yfit, 'r--', linewidth=3)

--- a/scripts/pfp_plot.py
+++ b/scripts/pfp_plot.py
@@ -1006,18 +1006,18 @@ def xy_xlims_changed(event_ax, fig, var):
     ax_xy.set_ylabel(var[1]["Label"]+" ("+var[1]["Attr"]["units"]+")")
     mask = numpy.ma.mask_or(numpy.ma.getmaskarray(var[0]["Data"][si:ei]),
                             numpy.ma.getmaskarray(var[1]["Data"][si:ei]))
-    x_nm = numpy.ma.compressed(numpy.ma.array(var[0]["Data"][si:ei], mask=mask))
+    x_nm = numpy.ma.compressed(numpy.ma.array(var[0]["Data"][si:ei], mask=mask, copy=True))
     if len(x_nm) == 0:
         return
     x_nm = sm.add_constant(x_nm,prepend=False)
-    y_nm = numpy.ma.compressed(numpy.ma.array(var[1]["Data"][si:ei], mask=mask))
+    y_nm = numpy.ma.compressed(numpy.ma.array(var[1]["Data"][si:ei], mask=mask, copy=True))
     if len(y_nm) == 0:
         return
     resrlm = sm.RLM(y_nm,x_nm,M=sm.robust.norms.TukeyBiweight()).fit()
     if numpy.isnan(resrlm.params[0]):
         resrlm = sm.RLM(y_nm,x_nm,M=sm.robust.norms.TrimmedMean()).fit()
-    r = numpy.corrcoef(numpy.ma.compressed(numpy.ma.array(var[0]["Data"][si:ei], mask=mask)),
-                       numpy.ma.compressed(numpy.ma.array(var[1]["Data"][si:ei], mask=mask)))
+    r = numpy.corrcoef(numpy.ma.compressed(numpy.ma.array(var[0]["Data"][si:ei], mask=mask, copy=True)),
+                       numpy.ma.compressed(numpy.ma.array(var[1]["Data"][si:ei], mask=mask, copy=True)))
     eqnstr = 'y = %.3fx + %.3f (RLM)'%(resrlm.params[0],resrlm.params[1])
     ax_xy.plot(x_nm[:,0],resrlm.fittedvalues,'r--',linewidth=3)
     ax_xy.text(0.5,0.93,eqnstr,fontsize=8,horizontalalignment='center',transform=ax_xy.transAxes)
@@ -1168,8 +1168,9 @@ def plot_quickcheck_seb(nFig, plot_title, figure_name, data, daily):
     Fe_30min = data["Fe"]["Data"]
     mask = numpy.ma.mask_or(Fa_30min.mask, Fe_30min.mask)
     mask = numpy.ma.mask_or(mask, Fh_30min.mask)
-    Fa_SEB = numpy.ma.array(Fa_30min, mask=mask)     # apply the mask
-    FhpFe_SEB = numpy.ma.array(Fh_30min, mask=mask) + numpy.ma.array(Fe_30min, mask=mask)
+    Fa_SEB = numpy.ma.array(Fa_30min, mask=mask, copy=True)
+    FhpFe_SEB = (numpy.ma.array(Fh_30min, mask=mask, copy=True) +
+                 numpy.ma.array(Fe_30min, mask=mask, copy=True))
     plt.ion()
     fig = plt.figure(nFig, figsize=(8, 8))
     fig.canvas.manager.set_window_title("Surface Energy Balance")
@@ -1178,9 +1179,9 @@ def plot_quickcheck_seb(nFig, plot_title, figure_name, data, daily):
     # scatter plot of (Fh+Fe) versus Fa, 24 hour averages
     mask = numpy.ma.mask_or(daily["Fa"]["Data"].mask, daily["Fe"]["Data"].mask)
     mask = numpy.ma.mask_or(mask, daily["Fh"]["Data"].mask)
-    Fa_daily = numpy.ma.array(daily["Fa"]["Data"], mask=mask)         # apply the mask
-    Fe_daily = numpy.ma.array(daily["Fe"]["Data"], mask=mask)
-    Fh_daily = numpy.ma.array(daily["Fh"]["Data"], mask=mask)
+    Fa_daily = numpy.ma.array(daily["Fa"]["Data"], mask=mask, copy=True)
+    Fe_daily = numpy.ma.array(daily["Fe"]["Data"], mask=mask, copy=True)
+    Fh_daily = numpy.ma.array(daily["Fh"]["Data"], mask=mask, copy=True)
     Fa_daily_avg = numpy.ma.average(Fa_daily, axis=1)      # get the daily average
     Fe_daily_avg = numpy.ma.average(Fe_daily, axis=1)
     Fh_daily_avg = numpy.ma.average(Fh_daily, axis=1)
@@ -1194,9 +1195,9 @@ def plot_quickcheck_seb(nFig, plot_title, figure_name, data, daily):
     Fh_day = numpy.ma.masked_where(day_mask == False, Fh_30min)
     mask = numpy.ma.mask_or(Fa_day.mask, Fe_day.mask)
     mask = numpy.ma.mask_or(mask, Fh_day.mask)
-    Fa_day = numpy.ma.array(Fa_day, mask=mask)         # apply the mask
-    Fe_day = numpy.ma.array(Fe_day, mask=mask)
-    Fh_day = numpy.ma.array(Fh_day, mask=mask)
+    Fa_day = numpy.ma.array(Fa_day, mask=mask, copy=True)
+    Fe_day = numpy.ma.array(Fe_day, mask=mask, copy=True)
+    Fh_day = numpy.ma.array(Fh_day, mask=mask, copy=True)
     FhpFe_day = Fh_day + Fe_day
     xyplot(Fa_day, FhpFe_day, sub=[2,2,3], regr=1, title="Day", xlabel="Fa (W/m^2)", ylabel="Fh+Fe (W/m^2)")
     # scatter plot of (Fh+Fe) versus Fa, night time
@@ -1206,9 +1207,9 @@ def plot_quickcheck_seb(nFig, plot_title, figure_name, data, daily):
     Fh_night = numpy.ma.masked_where(night_mask==False, Fh_30min)
     mask = numpy.ma.mask_or(Fa_night.mask, Fe_night.mask)
     mask = numpy.ma.mask_or(mask, Fh_night.mask)
-    Fa_night = numpy.ma.array(Fa_night, mask=mask)         # apply the mask
-    Fe_night = numpy.ma.array(Fe_night, mask=mask)
-    Fh_night = numpy.ma.array(Fh_night, mask=mask)
+    Fa_night = numpy.ma.array(Fa_night, mask=mask, copy=True)
+    Fe_night = numpy.ma.array(Fe_night, mask=mask, copy=True)
+    Fh_night = numpy.ma.array(Fh_night, mask=mask, copy=True)
     FhpFe_night = Fh_night + Fe_night
     xyplot(Fa_night, FhpFe_night, sub=[2,2,4], regr=1, title="Night", xlabel="Fa (W/m^2)", ylabel="Fh+Fe (W/m^2)")
     # hard copy of plot
@@ -1231,9 +1232,9 @@ def plot_quickcheck_get_seb(daily):
     mask = numpy.ma.mask_or(Fa_day.mask, Fe_day.mask)
     mask = numpy.ma.mask_or(mask, Fh_day.mask)
     # apply the mask
-    Fa_day = numpy.ma.array(Fa_day, mask=mask)
-    Fe_day = numpy.ma.array(Fe_day, mask=mask)
-    Fh_day = numpy.ma.array(Fh_day, mask=mask)
+    Fa_day = numpy.ma.array(Fa_day, mask=mask, copy=True)
+    Fe_day = numpy.ma.array(Fe_day, mask=mask, copy=True)
+    Fh_day = numpy.ma.array(Fh_day, mask=mask, copy=True)
     # get the daily averages
     Fa_day_avg = numpy.ma.average(Fa_day, axis=1)
     Fe_day_avg = numpy.ma.average(Fe_day, axis=1)
@@ -1259,8 +1260,8 @@ def plot_quickcheck_get_ef(daily):
     # mask based on dependencies, set all to missing if any missing
     mask = numpy.ma.mask_or(Fa_day.mask, Fe_day.mask)
     # apply the mask
-    Fa_day = numpy.ma.array(Fa_day, mask=mask)
-    Fe_day = numpy.ma.array(Fe_day, mask=mask)
+    Fa_day = numpy.ma.array(Fa_day, mask=mask, copy=True)
+    Fe_day = numpy.ma.array(Fe_day, mask=mask, copy=True)
     # get the daily averages
     Fa_day_avg = numpy.ma.average(Fa_day, axis=1)
     Fe_day_avg = numpy.ma.average(Fe_day, axis=1)
@@ -1285,8 +1286,8 @@ def plot_quickcheck_get_br(daily):
     # mask based on dependencies, set all to missing if any missing
     mask = numpy.ma.mask_or(Fe_day.mask, Fh_day.mask)
     # apply the mask
-    Fe_day = numpy.ma.array(Fe_day, mask=mask)
-    Fh_day = numpy.ma.array(Fh_day, mask=mask)
+    Fe_day = numpy.ma.array(Fe_day, mask=mask, copy=True)
+    Fh_day = numpy.ma.array(Fh_day, mask=mask, copy=True)
     # get the daily averages
     Fe_day_avg = numpy.ma.average(Fe_day, axis=1)
     Fh_day_avg = numpy.ma.average(Fh_day, axis=1)
@@ -1311,8 +1312,8 @@ def plot_quickcheck_get_wue(daily):
     # mask based on dependencies, set all to missing if any missing
     mask = numpy.ma.mask_or(Fe_day.mask, Fc_day.mask)
     # apply the mask
-    Fe_day = numpy.ma.array(Fe_day,mask=mask)
-    Fc_day = numpy.ma.array(Fc_day,mask=mask)
+    Fe_day = numpy.ma.array(Fe_day,mask=mask, copy=True)
+    Fc_day = numpy.ma.array(Fc_day,mask=mask, copy=True)
     # get the daily averages
     Fe_day_avg = numpy.ma.average(Fe_day, axis=1)
     Fc_day_avg = numpy.ma.average(Fc_day, axis=1)
@@ -1982,7 +1983,7 @@ def xyplot(x,y,sub=[1,1,1],regr=0,thru0=0,title=None,xlabel=None,ylabel=None,fna
         return
     if regr==1:
         coefs = numpy.ma.polyfit(numpy.ma.copy(x),numpy.ma.copy(y),1)
-        xfit = numpy.ma.array([numpy.ma.min(x),numpy.ma.max(x)])
+        xfit = numpy.ma.array([numpy.ma.min(x),numpy.ma.max(x)], copy=True)
         yfit = numpy.polyval(coefs,xfit)
         r = numpy.ma.corrcoef(x,y)
         eqnstr = 'y = %.3fx + %.3f (OLS)'%(coefs[0],coefs[1])

--- a/scripts/pfp_rp.py
+++ b/scripts/pfp_rp.py
@@ -289,7 +289,7 @@ def EcoResp(ds, l6_info, called_by, xl_writer):
         # Pass the dataframe to the respiration class and get the results
         ptc = pfp_part.partition(df, xl_writer, l6_info)
         params_df = ptc.estimate_parameters(mode = er_mode)
-        ER["Data"] = numpy.ma.array(ptc.estimate_er_time_series(params_df))
+        ER["Data"] = numpy.ma.array(ptc.estimate_er_time_series(params_df), copy=True)
         ER["Flag"] = numpy.tile(30, len(ER["Data"]))
         # Write ER to data structure
         drivers = iel["outputs"][output]["drivers"]
@@ -2126,7 +2126,7 @@ def rp_plot(pd, ds, output, drivers, target, iel, called_by, si=0, ei=-1):
     ax1 = plt.axes(rect1)
     # get the diurnal stats of the observations
     mask = numpy.ma.mask_or(obs["Data"].mask, mod["Data"].mask)
-    obs_mor = numpy.ma.array(obs["Data"], mask=mask)
+    obs_mor = numpy.ma.array(obs["Data"], mask=mask, copy=True)
     dstats = pfp_utils.get_diurnalstats(dt, obs_mor, ieli)
     ax1.plot(dstats["Hr"], dstats["Av"], 'b-', label="Obs")
     # get the diurnal stats of all predictions
@@ -2149,7 +2149,7 @@ def rp_plot(pd, ds, output, drivers, target, iel, called_by, si=0, ei=-1):
     # plot the best fit line
     coefs = numpy.ma.polyfit(numpy.ma.copy(mod["Data"]), numpy.ma.copy(obs["Data"]), 1)
     xfit = numpy.ma.array([numpy.ma.minimum.reduce(mod["Data"]),
-                           numpy.ma.maximum.reduce(mod["Data"])])
+                           numpy.ma.maximum.reduce(mod["Data"])], copy=True)
     yfit = numpy.polyval(coefs, xfit)
     r = numpy.ma.corrcoef(mod["Data"], obs["Data"])
     ax2.plot(xfit, yfit, 'r--', linewidth=3)

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -1953,8 +1953,8 @@ def get_laggedcorrelation(x_in,y_in,maxlags):
     """
     lags = numpy.arange(-maxlags,maxlags+1)
     mask = numpy.ma.mask_or(x_in.mask,y_in.mask,copy=True,shrink=False)
-    x = numpy.ma.array(x_in,mask=mask,copy=True)
-    y = numpy.ma.array(y_in,mask=mask,copy=True)
+    x = numpy.ma.array(x_in, mask=mask, copy=True)
+    y = numpy.ma.array(y_in, mask=mask, copy=True)
     x = numpy.ma.compressed(x)
     y = numpy.ma.compressed(y)
     corr = numpy.correlate(x, y, mode=2)
@@ -2150,7 +2150,7 @@ def get_synthetic_fsd(ds):
     Fsd_syn["Data"] = [pysolar.GetRadiationDirect(dt, alt)
                        for dt, alt in
                        zip(ldt_UTC, solar_altitude["Data"])]
-    Fsd_syn["Data"] = numpy.ma.array(Fsd_syn["Data"])
+    Fsd_syn["Data"] = numpy.ma.array(Fsd_syn["Data"], copy=True)
     # get the QC flag
     Fsd_syn["Flag"] = numpy.zeros(nrecs, dtype=numpy.int32)
     # add the synthetic downwelling shortwave radiation to the data structure
@@ -2819,10 +2819,10 @@ def ReplaceWhereMissing(Destination,Primary,Secondary,FlagOffset=None,FlagValue=
 
 def ReplaceWhenDiffExceedsRange(DateTime,Destination,Primary,Secondary,RList):
     # get the primary data series
-    p_data = numpy.ma.array(Primary['Data'])
+    p_data = numpy.ma.array(Primary['Data'], copy=True)
     p_flag = Primary['Flag'].copy()
     # get the secondary data series
-    s_data = numpy.ma.array(Secondary['Data'])
+    s_data = numpy.ma.array(Secondary['Data'], copy=True)
     # truncate the longest series if the sizes do not match
     if numpy.size(p_data)!=numpy.size(s_data):
         logger.warning(' ReplaceWhenDiffExceedsRange: Series lengths differ, longest will be truncated')

--- a/scripts/pfp_utils.py
+++ b/scripts/pfp_utils.py
@@ -1291,7 +1291,7 @@ def CreateEmptyVariable(label, nrecs, datetime=None, out_type="ma", attr=None):
     """
     data = numpy.ones(nrecs, dtype=numpy.float64)*float(c.missing_value)
     if out_type == "ma":
-        data = numpy.ma.array(data, mask=True)
+        data = numpy.ma.array(data, mask=True, copy=True)
     flag = numpy.ones(nrecs, dtype=numpy.int32)
     attr_new = make_attribute_dictionary(attr=attr)
     variable = {"Label": label, "Data": data, "Flag": flag, "Attr": attr_new}
@@ -2137,7 +2137,7 @@ def get_datetime_from_excel_date(values, xl_datemode):
     xl_date = values + 1462*int(xl_datemode)
     base_date = datetime.datetime(1899, 12, 30)
     dt = [base_date + datetime.timedelta(days=xl_date[i]) for i in range(len(values))]
-    return numpy.ma.array(dt)
+    return numpy.ma.array(dt, copy=True)
 
 def get_datetime_from_xldatetime(ds):
     ''' Creates a series of Python datetime objects from the Excel date read from the Excel file.
@@ -2205,7 +2205,7 @@ def get_diurnalstats(dt,data,info):
     ndays = len(data_wholedays)//nperday
     data_2d = numpy.ma.reshape(data_wholedays,[ndays,nperday])
     diel_stats = {}
-    diel_stats["Hr"] = numpy.ma.array([i*ts/float(60) for i in range(0,nperday)])
+    diel_stats["Hr"] = numpy.ma.array([i*ts/float(60) for i in range(0,nperday)], copy=True)
     diel_stats["Av"] = numpy.ma.average(data_2d,axis=0)
     diel_stats["Sd"] = numpy.ma.std(data_2d,axis=0)
     diel_stats["Mx"] = numpy.ma.max(data_2d,axis=0)
@@ -2620,7 +2620,7 @@ def get_xldatefromdatetime(ds):
                                                       ldt[i].minute,
                                                       ldt[i].second),
                                                       datemode) for i in range(0,len(ldt))]
-    xldt_new = numpy.ma.array(xldate, dtype=numpy.float64)
+    xldt_new = numpy.ma.array(xldate, dtype=numpy.float64, copy=True)
     # create the Excel datetime series
     var = {"Label": "xlDateTime", "Data": xldt_new, "Flag": flag, "Attr": xldt_attr}
     CreateVariable(ds, var)


### PR DESCRIPTION
The MDS C code behaves as follows:

1. If the data set starts at YYYY-12-31 23:30 or earlier then the whole of year YYYY is filled and the output data starts at YYYY-01-01 00:30.
2. If the data set starts at YYYY+1-01-01 00:00 then this data point is discarded, the output data starts at YYYY+1-01-01 00:30 and the gap filled data returned by MDS is 1 point shorter than the input data.
3. If the data set starts at YYYY+1-01-01 00:30 then the gap filled data set starts at YYYY+1-01-01 00:30.

The pfp_gfMDS.gfMDS_get_mds_output() now explicitly handles the second case.