### PR TITLE
Deal with syntax warnings generated by Python V3.12.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: pfp_env
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python==3.11
   - configobj
   - python-dateutil
   - lmfit

--- a/scripts/pfp_cpd_mcnew.py
+++ b/scripts/pfp_cpd_mcnew.py
@@ -763,7 +763,7 @@ def plot_ustar_threshold(df, num_cats=30, ustar_threshold=None):
     fig, ax1 = plt.subplots(1, figsize = (12, 8))
     fig.patch.set_facecolor('white')
     ax1.set_ylabel(r'$R_e\/(\mu mol\/m^{-2}\/s^{-1})$', fontsize = 18)
-    ax1.set_xlabel('$u_{*}\/(m\/s^{-1})$', fontsize = 18)
+    ax1.set_xlabel(r'$u_{*}\/(m\/s^{-1})$', fontsize = 18)
     ax1.tick_params(axis = 'x', labelsize = 14)
     ax1.tick_params(axis = 'y', labelsize = 14)
     ax1.yaxis.set_ticks_position('left')

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -398,7 +398,7 @@ def csv_read_parse_cf(cf):
     # define the missing values and the value with which to fill them
     info["missing_values"] = "NA,N/A,NAN,NaN,nan,#NAME?,#VALUE!,#DIV/0!,#REF!,Infinity,-Infinity"
     info["filling_values"] = c.missing_value
-    info["deletechars"] = set("""~!@#$%^&=+~\|]}[{';: ?.>,<""")
+    info["deletechars"] = set("""~!@#$%^&=+~|]}[{';: ?.>,<""")
 
     info["cf_ok"] = True
 

--- a/scripts/pfp_part.py
+++ b/scripts/pfp_part.py
@@ -463,8 +463,8 @@ class partition(object):
         ax.tick_params(axis = 'y', labelsize = 14)
         ax.tick_params(axis = 'x', labelsize = 14)
         ax.set_title(dt.datetime.strftime(date, '%Y-%m-%d'), fontsize = 18)
-        ax.set_xlabel('$Temperature\/(^oC)$', fontsize = 18)
-        ax.set_ylabel('$NEE\/(\mu molC\/m^{-2}\/s^{-1})$', fontsize = 18)
+        ax.set_xlabel('$Temperature (degC)', fontsize = 18)
+        ax.set_ylabel('$NEE (umol/m^2/s)', fontsize = 18)
         labels_dict = {'night': 'Night Eo and rb', 'day': 'Night Eo, day rb'}
         styles_dict = {'night': '--', 'day': ':'}
         ax.plot(df.TC, df.NEE, color = 'None', marker = 'o',
@@ -511,9 +511,9 @@ class partition(object):
         ax.tick_params(axis = 'x', labelsize = 14)
         ax.set_title(dt.datetime.strftime(date.to_pydatetime(), '%Y-%m-%d'),
                      fontsize = 18)
-        ax.set_xlabel('$PPFD\/(\mu mol\/photons\/m^{-2}\/s^{-1})$',
+        ax.set_xlabel(r'$PPFD\/(\mu mol\/photons\/m^{-2}\/s^{-1})$',
                       fontsize = 18)
-        ax.set_ylabel('$NEE\/(\mu molC\/m^{-2}\/s^{-1})$', fontsize = 18)
+        ax.set_ylabel(r'$NEE\/(\mu molC\/m^{-2}\/s^{-1})$', fontsize = 18)
         labels_dict = {'night': 'Night Eo and rb', 'day': 'Night Eo, day rb'}
         markers_dict = {'night': '+', 'day': 'x'}
         colors_dict = {'night': 'blue', 'day': 'magenta'}

--- a/scripts/pfp_utils.py
+++ b/scripts/pfp_utils.py
@@ -1096,7 +1096,7 @@ def convert_anglestring(anglestring):
     quadlist = ["N", "E", "S", "W"]
     direction = {'N':1, 'S':-1, 'E': 1, 'W':-1}
     # replace the degrees, minutes and seconds symbols with spaces
-    new = anglestring.replace('\B0', ' ').replace('\'', ' ').replace('"', ' ').strip()
+    new = anglestring.replace(r'\B0', ' ').replace('\'', ' ').replace('"', ' ').strip()
     try:
         # simple casting may work, who knows?
         anglefloat = float(new)


### PR DESCRIPTION
Escape sequences using a backslash generate warnings under Python V3.12, prefixed these strings with "r" to indicate a raw string.