### PR TITLE
Clean up behaviour if L5 driver contains missing data.

### DIFF
--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -914,16 +914,12 @@ def gfSOLO_runsofm(dsb, drivers, targetlabel, nRecs, solo, si=0, ei=-1):
         driver["Data"] = numpy.ma.filled(driver["Data"], c.missing_value)
         index = numpy.where(abs(driver["Data"]-c.missing_value)<c.eps)[0]
         if len(index) != 0:
-            msg = " GapFillUsingSOLO: missing value found in driver " + label + " at lines " + str(index)
+            msg = " GapFillUsingSOLO: " + str(len(index)) + " missing values found in driver " + label
             logger.error(msg)
             badlines = badlines + index.tolist()
             for n in index:
                 baddates.append(dsb.root["Variables"]["DateTime"]["Data"][n])
                 badvalues.append(dsb.root["Variables"][label]["Data"][n])
-            msg = " GapFillUsingSOLO: driver values: " + str(badvalues)
-            logger.error(msg)
-            msg = " GapFillUsingSOLO: datetimes: " + str(baddates)
-            logger.error(msg)
         sofminputdata[:, i] = driver["Data"][:]
         i = i + 1
     if len(badlines) != 0:
@@ -931,7 +927,7 @@ def gfSOLO_runsofm(dsb, drivers, targetlabel, nRecs, solo, si=0, ei=-1):
         goodlines = [x for x in range(0, nRecs) if x not in badlines]
         sofminputdata = sofminputdata[goodlines, :]
         msg = " GapFillUsingSOLO: removed " + str(nBad) + " lines from sofm input file"
-        logger.info(msg)
+        logger.error(msg)
         nRecs = len(goodlines)
     # now write the drivers to the SOFM input file
     sofm_input = os.path.join(td, "input", "sofm_input.csv")

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -11489,7 +11489,14 @@ class solo_gui(QtWidgets.QDialog):
         self.QuitButton.clicked.connect(self.call_gui_quit)
 
     def call_gui_run(self):
-        pfp_gfSOLO.gfSOLO_run_interactive(self)
+        try:
+            pfp_gfSOLO.gfSOLO_run_interactive(self)
+        except Exception:
+            msg = "Error occurred during SOLO processing "
+            logger.error(msg)
+            error_message = traceback.format_exc()
+            logger.error(error_message)
+            pfp_gfSOLO.gfSOLO_quit(self)
 
     def call_gui_quit(self):
         pfp_gfSOLO.gfSOLO_quit(self)

--- a/scripts/pfp_levels.py
+++ b/scripts/pfp_levels.py
@@ -284,6 +284,8 @@ def l5qc(main_gui, cf, ds4):
     pfp_io.TruncateDataStructure(ds5, l5_info)
     # check for missing data in the drivers
     pfp_gf.CheckL5Drivers(ds5, l5_info)
+    if ds5.info["returncodes"]["value"] != 0:
+        return ds5
     # now do the flux gap filling methods
     # *** start of the section that does the gap filling of the fluxes ***
     pfp_gf.CheckGapLengths(cf, ds5, l5_info)


### PR DESCRIPTION
L5 now stops if a driver contains missing data.
L5 exceptions now printed to log window and PFP remains open.