### PR TITLE
fixed get height in CalculateSco2SinglePoint from CO2 variable attrib…

### DIFF
--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -1279,7 +1279,7 @@ def CalculateSco2SinglePoint(ds, Sco2_out="Sco2_single"):
                 logger.warning(msg)
                 return
         if "height" in ds.root["Variables"]["CO2"]["Attr"]:
-            height = pfp_utils.strip_non_numeric(ds.root["Variables"]["CO2"]["Attr"]["height"])
+            height = pfp_utils.strip_non_numeric(str(ds.root["Variables"]["CO2"]["Attr"]["height"]))
             height = float(height)
         else:
             msg = " 'height' attribute missing from CO2 variable, Sco2 not calculated"


### PR DESCRIPTION
When calling CalculateSco2SinglePoint, height was pulled from CO2variable attribute but not defined as string. Just added str to pfp_utils.strip_non_numeric(ds.root["Variables"]["CO2"]["Attr"]["height"]) ==> pfp_utils.strip_non_numeric(str(ds.root["Variables"]["CO2"]["Attr"]["height"])). Works now.