### PR TITLE
Revert to cftime

### DIFF
--- a/scripts/pfp_cpd_mchugh.py
+++ b/scripts/pfp_cpd_mchugh.py
@@ -431,7 +431,7 @@ def CPD_run(cf):
     #fig.savefig(plot_out_name)
     #if d["show_plots"]:
         #plt.draw()
-        #pfp_utils.mypause(0.5)
+        #pfp_utils.mypause(1)
         #plt.ioff()
     #else:
         #plt.ion()
@@ -459,7 +459,7 @@ def CPD_run(cf):
     #fig.savefig(plot_out_name)
     #if d["show_plots"]:
         #plt.draw()
-        #pfp_utils.mypause(0.5)
+        #pfp_utils.mypause(1)
         #plt.ioff()
     #else:
         #plt.ion()

--- a/scripts/pfp_gfALT.py
+++ b/scripts/pfp_gfALT.py
@@ -1028,9 +1028,10 @@ def gfalternate_plotcomposite(data_dict, stat_dict, diel_avg, l4a, pd):
     fig.savefig(figname, format='png')
     # draw the plot on the screen
     if l4a["gui"]["show_plots"]:
-        plt.draw()
-        pfp_utils.mypause(1)
-        plt.ioff()
+        #plt.draw()
+        #pfp_utils.mypause(0.5)
+        #plt.ioff()
+        fig.canvas.flush_events()
     else:
         plt.close()
         plt.switch_backend(current_backend)
@@ -1097,9 +1098,10 @@ def gfalternate_plotcoveragelines(ds_tower, l4_info, called_by):
     pylab.yticks(ylabel_posn, ylabel_right_list)
     fig.tight_layout()
     if l4a["gui"]["show_plots"]:
-        plt.draw()
-        pfp_utils.mypause(1)
-        plt.ioff()
+        #plt.draw()
+        #pfp_utils.mypause(1)
+        #plt.ioff()
+        fig.canvas.flush_events()
     else:
         plt.switch_backend(current_backend)
         plt.ion()
@@ -1191,9 +1193,10 @@ def gfalternate_plotsummary(l4_info):
         figname += "_" + startdate.strftime("%Y%m%d") + "_" + enddate.strftime("%Y%m%d") + ".png"
         fig.savefig(figname, format="png")
         if l4ig["show_plots"]:
-            plt.draw()
-            pfp_utils.mypause(0.5)
-            plt.ioff()
+            #plt.draw()
+            #pfp_utils.mypause(1)
+            #plt.ioff()
+            fig.canvas.flush_events()
         else:
             plt.close()
             plt.switch_backend(current_backend)

--- a/scripts/pfp_gfMDS.py
+++ b/scripts/pfp_gfMDS.py
@@ -420,9 +420,10 @@ def gfMDS_plot(pd, ds, mds_label, l5_info, called_by):
     figure_path = os.path.join(l5_info[called_by]["info"]["plot_path"], figure_name)
     fig.savefig(figure_path, format='png')
     if pd["show_plots"]:
-        plt.draw()
-        pfp_utils.mypause(0.5)
-        plt.ioff()
+        #plt.draw()
+        #pfp_utils.mypause(1)
+        #plt.ioff()
+        fig.canvas.flush_events()
     else:
         plt.close(fig)
         plt.ion()

--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -483,9 +483,12 @@ def gfSOLO_plot(pd, ds, drivers, target, output, l5s, si=0, ei=-1):
     fig.savefig(figname, format="png")
     # draw the plot on the screen
     if l5s["gui"]["show_plots"]:
-        plt.draw()
-        pfp_utils.mypause(0.5)
-        plt.ioff()
+        #plt.draw()
+        #plt.show()
+        #plt.pause(0.5)
+        #pfp_utils.mypause(5)
+        #plt.ioff()
+        fig.canvas.flush_events()
     else:
         plt.close()
         plt.switch_backend(current_backend)
@@ -553,9 +556,10 @@ def gfSOLO_plotcoveragelines(ds, l5_info, called_by):
     ax2.set_yticklabels(ylabel_right_list)
     fig.tight_layout()
     if l5s["gui"]["show_plots"]:
-        plt.draw()
-        pfp_utils.mypause(0.5)
-        plt.ioff()
+        #plt.draw()
+        #pfp_utils.mypause(1)
+        #plt.ioff()
+        fig.canvas.flush_events()
     else:
         plt.switch_backend(current_backend)
         plt.ion()
@@ -638,9 +642,10 @@ def gfSOLO_plotsummary(ds, solo):
     figname = figname + "_" + sdt + "_" + edt + ".png"
     fig.savefig(figname, format="png")
     if solo["gui"]["show_plots"]:
-        plt.draw()
-        pfp_utils.mypause(0.5)
-        plt.ioff()
+        #plt.draw()
+        #pfp_utils.mypause(0.5)
+        #plt.ioff()
+        fig.canvas.flush_events()
     else:
         plt.close()
         plt.switch_backend(current_backend)

--- a/scripts/pfp_part.py
+++ b/scripts/pfp_part.py
@@ -581,9 +581,10 @@ class partition(object):
         fig.savefig(file_name, format="png")
 
         if self.l6_info["Options"]["call_mode"] == "interactive":
-            plt.draw()
-            pfp_utils.mypause(0.5)
-            plt.ioff()
+            #plt.draw()
+            #pfp_utils.mypause(1)
+            #plt.ioff()
+            fig.canvas.flush_events()
         else:
             plt.close()
             plt.switch_backend(current_backend)
@@ -628,9 +629,10 @@ class partition(object):
         fig.savefig(file_name, format="png")
 
         if self.l6_info["Options"]["call_mode"] == "interactive":
-            plt.draw()
-            pfp_utils.mypause(0.5)
-            plt.ioff()
+            #plt.draw()
+            #pfp_utils.mypause(1)
+            #plt.ioff()
+            fig.canvas.flush_events()
         else:
             plt.close()
             plt.switch_backend(current_backend)

--- a/scripts/pfp_plot.py
+++ b/scripts/pfp_plot.py
@@ -84,9 +84,10 @@ def checktimestamps_plots(df, sheet, l1_info):
     # interactive or batch?
     if show_plots.lower() == "yes":
         # interactive so render the plot, pause 0.5 seconds, turn interactive plotting off
-        plt.draw()
-        pfp_utils.mypause(0.5)
-        plt.ioff()
+        #plt.draw()
+        #pfp_utils.mypause(1)
+        #plt.ioff()
+        fig.canvas.flush_events()
     else:
         # batch so close the figure, switch to previous backend
         plt.close(fig)
@@ -265,7 +266,7 @@ def plot_fcvsustar_annual(ds):
             axs.set_ylim([min(means-stdevs), max(means+stdevs)])
         axs.set_title(site_name+": "+str(year))
         plt.draw()
-        pfp_utils.mypause(0.5)
+        pfp_utils.mypause(1)
     return
 
 def plot_fcvsustar_seasonal(ds):
@@ -352,7 +353,7 @@ def plot_fcvsustar_seasonal(ds):
                 axs[row, col].set_ylim([min(means-stdevs), max(means+stdevs)])
         fig.tight_layout()
         plt.draw()
-        pfp_utils.mypause(0.5)
+        pfp_utils.mypause(1)
     plt.ioff()
     return
 
@@ -438,7 +439,7 @@ def plot_fcvsustar_monthly(ds):
                 axs[nrow, ncol].set_ylim([min(means-stdevs), max(means+stdevs)])
         fig.tight_layout()
         plt.draw()
-        pfp_utils.mypause(0.5)
+        pfp_utils.mypause(1)
     plt.ioff()
     return
 
@@ -616,9 +617,10 @@ def plot_fingerprint(cf):
         pngname = pngname + title.replace(" ", "_") + ".png"
         fig.savefig(pngname, format="png")
         if show_plots:
-            plt.draw()
-            pfp_utils.mypause(0.5)
-            plt.ioff()
+            #plt.draw()
+            #pfp_utils.mypause(1)
+            #plt.ioff()
+            fig.canvas.flush_events()
         else:
             plt.close(fig)
             plt.switch_backend(current_backend)
@@ -662,7 +664,7 @@ def plot_fluxnet(cf):
         figname += '_' + ds.root["Attributes"]['processing_level'] + '_FC_' + label + '.png'
         fig.savefig(figname, format='png')
         plt.draw()
-        pfp_utils.mypause(0.5)
+        pfp_utils.mypause(1)
     plt.ioff()
     return
 
@@ -756,7 +758,7 @@ def plot_explore_fingerprints(ds, selections):
     # render the fingerprint
     plt.draw()
     # pause to let the image appear on the creen
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     # turn off interactive plotting mode
     plt.ioff()
     return
@@ -798,7 +800,7 @@ def plot_explore_histograms(ds, labels):
             ax_hist.set_xticks([x[1], x[-2]])
             ax_hist.set_xticklabels([lwrs, uprs])
         plt.draw()
-        pfp_utils.mypause(0.5)
+        pfp_utils.mypause(1)
     return
 
 def plot_explore_do_histogram(var, plwr, pupr):
@@ -856,7 +858,7 @@ def plot_explore_percentiles(ds, selections):
                 ax_hist.set_xticks([x[1], x[-2]])
                 ax_hist.set_xticklabels([lwrs, uprs])
             plt.draw()
-            pfp_utils.mypause(0.5)
+            pfp_utils.mypause(1)
     return
 
 def plot_explore_timeseries(ds, selections):
@@ -894,7 +896,7 @@ def plot_explore_timeseries(ds, selections):
             axs[n].set_ylabel("(" + var["Attr"]["units"] + ")")
             n += 1
     plt.draw()
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     plt.ioff()
     return
 
@@ -1212,7 +1214,7 @@ def plottimeseries(cf, nFig, dsa, dsb):
     # draw the plot on the screen
     if show_plots.lower() == "yes":
         plt.draw()
-        pfp_utils.mypause(0.5)
+        pfp_utils.mypause(1)
         plt.ioff()
     else:
         plt.close(fig)
@@ -1501,7 +1503,7 @@ def plot_quickcheck(cf):
     file_name = site_name.replace(" ", "") + "_" + level + "_QC_SEB_30minutes.png"
     figure_name = os.path.join("plots", file_name)
     plot_quickcheck_seb(nFig, plot_title, figure_name, data, daily)
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     # plot the daily ratios
     cmap = plt.cm.get_cmap("RdYlBu")
     logger.info(" Doing the daily ratios plot")
@@ -1521,7 +1523,7 @@ def plot_quickcheck(cf):
     figure_name = os.path.join("plots", file_name)
     fig.savefig(figure_name, format="png")
     plt.draw()
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     # plot the daily average radiation
     nFig = nFig + 1
     fig = plt.figure(nFig, figsize=(9, 6))
@@ -1538,7 +1540,7 @@ def plot_quickcheck(cf):
     figure_name = os.path.join("plots", file_name)
     fig.savefig(figure_name, format="png")
     plt.draw()
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     # plot the daily average fluxes
     nFig = nFig + 1
     fig = plt.figure(nFig, figsize=(9, 6))
@@ -1556,7 +1558,7 @@ def plot_quickcheck(cf):
     figure_name = os.path.join("plots", file_name)
     fig.savefig(figure_name, format="png")
     plt.draw()
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     # plot the daily average meteorology
     nFig = nFig + 1
     fig = plt.figure(nFig, figsize=(9, 6))
@@ -1573,7 +1575,7 @@ def plot_quickcheck(cf):
     figure_name = os.path.join("plots", file_name)
     fig.savefig(figure_name, format="png")
     plt.draw()
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     # plot the daily average soil data
     nFig = nFig + 1
     fig = plt.figure(nFig, figsize=(9, 6))
@@ -1590,7 +1592,7 @@ def plot_quickcheck(cf):
     figure_name = os.path.join("plots", file_name)
     fig.savefig(figure_name, format="png")
     plt.draw()
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     # *** end of section for time series of daily averages
     # *** start of section for diurnal plots by month ***
     # month labels
@@ -1662,7 +1664,7 @@ def plot_quickcheck(cf):
         fig.savefig(figure_name, format="png")
         # draw the plot on the screen
         plt.draw()
-        pfp_utils.mypause(0.5)
+        pfp_utils.mypause(1)
     plt.ioff()
     return
 
@@ -1714,7 +1716,7 @@ def plot_stacked_timeseries(cfg, ds, start=0, end=-1):
     fig.savefig(pngname, format="png")
     if show_plots:
         plt.draw()
-        pfp_utils.mypause(0.5)
+        pfp_utils.mypause(1)
         plt.ioff()
     else:
         plt.close(fig)
@@ -1961,7 +1963,7 @@ def plot_windrose_all(ds, wrinfo):
     file_name = site_name.replace(" ","") + "_" + level + "_" + "windrose_all" + ".png"
     file_name = os.path.join(wrinfo["plot_path"], file_name)
     fig.savefig(file_name, format="png")
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     plt.ioff()
     return
 
@@ -2017,7 +2019,7 @@ def plot_windrose_seasonal(ds, wrinfo):
     file_name = site_name.replace(" ","") + "_" + level + "_" + "windrose_seasonal" + ".png"
     file_name = os.path.join(wrinfo["plot_path"], file_name)
     fig.savefig(file_name, format="png")
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     plt.ioff()
     return
 
@@ -2060,7 +2062,7 @@ def plotxy(cf, title, plt_cf, dsa, dsb):
             xyplot(xa["Data"], ya["Data"], sub=[1,2,1], xlabel=xname, ylabel=yname)
             xyplot(xb["Data"], yb["Data"], sub=[1,2,2], regr=1, xlabel=xname, ylabel=yname)
     plt.draw()
-    pfp_utils.mypause(0.5)
+    pfp_utils.mypause(1)
     plot_path = pfp_utils.get_keyvaluefromcf(cf, ["Files"], "plot_path", default="plots/")
     if not os.path.exists(plot_path):
         os.makedirs(plot_path)
@@ -2069,7 +2071,7 @@ def plotxy(cf, title, plt_cf, dsa, dsb):
     # draw the plot on the screen
     if show_plots.lower() == "yes":
         plt.draw()
-        pfp_utils.mypause(0.5)
+        pfp_utils.mypause(1)
         plt.ioff()
     else:
         plt.close(fig)

--- a/scripts/pfp_rp.py
+++ b/scripts/pfp_rp.py
@@ -553,9 +553,10 @@ def L6_summary_plotdaily(ds_summary, l6_info):
         figure_path = os.path.join(plot_path, figure_name)
         fig.savefig(figure_path, format='png')
         if l6_info["Options"]["call_mode"].lower() == "interactive":
-            plt.draw()
-            pfp_utils.mypause(0.5)
-            plt.ioff()
+            #plt.draw()
+            #pfp_utils.mypause(1)
+            #plt.ioff()
+            fig.canvas.flush_events()
         else:
             plt.close(fig)
             plt.switch_backend(current_backend)
@@ -589,9 +590,10 @@ def L6_summary_plotdaily(ds_summary, l6_info):
     figname = figname+"_"+sdt+"_"+edt+'.png'
     fig.savefig(figname,format='png')
     if l6_info["Options"]["call_mode"].lower()=="interactive":
-        plt.draw()
-        pfp_utils.mypause(0.5)
-        plt.ioff()
+        #plt.draw()
+        #pfp_utils.mypause(1)
+        #plt.ioff()
+        fig.canvas.flush_events()
     else:
         plt.close(fig)
         plt.switch_backend(current_backend)
@@ -706,9 +708,10 @@ def L6_summary_plotcumulative(ds_summary, l6_info):
         figure_path = os.path.join(plot_path, figure_name)
         fig.savefig(figure_path, format='png')
         if l6_info["Options"]["call_mode"].lower() == "interactive":
-            plt.draw()
-            pfp_utils.mypause(0.5)
-            plt.ioff()
+            #plt.draw()
+            #pfp_utils.mypause(1)
+            #plt.ioff()
+            fig.canvas.flush_events()
         else:
             plt.close(fig)
             plt.switch_backend(current_backend)
@@ -2321,9 +2324,10 @@ def rp_plot(pd, ds, output, drivers, target, iel, called_by, si=0, ei=-1):
     fig.savefig(figname, format='png')
     # draw the plot on the screen
     if iel["gui"]["show_plots"]:
-        plt.draw()
-        pfp_utils.mypause(0.5)
-        plt.ioff()
+        #plt.draw()
+        #pfp_utils.mypause(1)
+        #plt.ioff()
+        fig.canvas.flush_events()
     else:
         #plt.close(fig)
         plt.close()

--- a/scripts/pfp_utils.py
+++ b/scripts/pfp_utils.py
@@ -10,6 +10,7 @@ import platform
 import sys
 import time
 # third party modules
+import cftime
 import dateutil
 import numpy
 import pytz
@@ -2122,38 +2123,13 @@ def get_datetime_from_nctime(ds):
     Author: PRI
     Date: September 2014
     """
-    if "nc_nrecs" in list(ds.root["Attributes"].keys()):
-        nRecs = int(ds.root["Attributes"]["nc_nrecs"])
-    else:
-        nRecs = len(ds.root["Variables"]["time"]["Data"])
-        ds.root["Attributes"]["nc_nrecs"] = nRecs
+    time_step = ds.root["Attributes"]["time_step"]
     nc_time_data = ds.root["Variables"]["time"]["Data"]
     nc_time_units = ds.root["Variables"]["time"]["Attr"]["units"]
-    # we only handle time units in days, hours or seconds
-    got_units_period = False
-    for units_period in ["days", "hours", "seconds"]:
-        if units_period in nc_time_units:
-            got_units_period = True
-            break
-    if not got_units_period:
-        msg = " 'days', 'hours' or 'seconds' not found in time units"
-        logger.error(msg)
-        raise RuntimeError
     # 20210912 PRI - deprecate num2pydate as part of SegFault testing
-    #dt = cftime.num2date(nc_time_data, nc_time_units)
-    # https://stackoverflow.com/questions/39986041/converting-days-since-epoch-to-date
-    epoch_start_date = dateutil.parser.parse(nc_time_units, fuzzy=True)
-    if units_period == "days":
-        dt = [epoch_start_date + datetime.timedelta(days=t) for t in nc_time_data]
-    elif units_period == "hours":
-        dt = [epoch_start_date + datetime.timedelta(hours=t) for t in nc_time_data]
-    elif units_period == "seconds":
-        dt = [epoch_start_date + datetime.timedelta(seconds=t) for t in nc_time_data]
-    else:
-        msg = " Unhandled option (" + str(units_period) + ") for time units period"
-        logger.error(msg)
-        raise RuntimeError
-    time_step = ds.root["Attributes"]["time_step"]
+    # 20250516 PRI - revet to using cftime
+    # 20250516 PRI - note that cftime.num2pydate() now returns real_datetime object
+    dt = cftime.num2pydate(nc_time_data, nc_time_units)
     if time_step in ["daily", "monthly", "annual"]:
         dt = numpy.array(dt)
     else:
@@ -2162,7 +2138,7 @@ def get_datetime_from_nctime(ds):
     calendar = "gregorian"
     if "calendar" in ds.root["Variables"]["time"]["Attr"]:
         calendar = ds.root["Variables"]["time"]["Attr"]["calendar"]
-    pydt = {"Label": "DateTime", "Data": dt, "Flag": numpy.zeros(nRecs),
+    pydt = {"Label": "DateTime", "Data": dt, "Flag": numpy.zeros(len(dt)),
             "Attr": {"long_name": "Datetime in local timezone", "units": "",
                      "calendar": calendar}}
     CreateVariable(ds, pydt)


### PR DESCRIPTION
Reverted to using cftime in pfp_utils.get_datetime_from_nctime().  cftime was dropped at one stage as a possible cause of segfaults.  Seems OK now.
Also replaced pfp_utils.mypause() and associated commands with fig.canvas.flush_events() to improve display of plots during L2 and L5.
Tested on Loxton, Calperum and Cumberland Plain.