### PR TITLE
Implement mad l5 and other stuff.

### DIFF
--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -818,8 +818,9 @@ class pfp_main_ui(QWidget):
             pfp_top_level.do_run_l4(self)
             self.actionRunCurrent.setDisabled(False)
         elif cfg["level"] == "L5":
-            if pfp_compliance.check_l5_controlfile(cfg):
-                pfp_top_level.do_run_l5(self)
+            if not pfp_compliance.check_l5_controlfile(cfg):
+                return
+            pfp_top_level.do_run_l5(self)
             self.actionRunCurrent.setDisabled(False)
         elif cfg["level"] == "L6":
             if pfp_compliance.check_l6_controlfile(cfg):

--- a/scripts/cfg.py
+++ b/scripts/cfg.py
@@ -1,5 +1,10 @@
 version_name = "PyFluxPro"
-version_number = "V3.4.18"
+version_number = "V3.4.19"
+# V3.4.19 - May 2025
+#         - implement MAD filter at L5
+#         - replace plt.draw()/pfp_utils.mypause() with fig.canvas.flush_events()
+#         - correct implementation of masking long gaps in GapFillUsingSOLO()
+#           and GapFillUsingMDS()
 # V3.4.18 - June 2024
 #         - L4 gap filling
 #           - force final window to equal user specified window length by

--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -180,7 +180,7 @@ def ApplyTurbulenceFilter(cf, ds, l5_info, ustar_threshold=None):
                                                      var["Data"], copy=True)
         var_filtered["Flag"] = numpy.copy(var["Flag"])
         idx = numpy.where(indicators["final"]["Data"] == 0)[0]
-        var_filtered["Flag"][idx] = numpy.int32(61)
+        var_filtered["Flag"][idx] = numpy.int32(502)
         # update the "description" attribute
         pfp_utils.append_to_attribute(var_filtered["Attr"], {descr_level: "turbulence filter applied"})
         # and write the filtered data to the data structure

--- a/scripts/pfp_gf.py
+++ b/scripts/pfp_gf.py
@@ -1132,7 +1132,7 @@ def gfSOLO_createdict_outputs(cf, l5_info, target, called_by, flag_code):
                                  "Var (obs)": [], "Var (SOLO)": [], "Var ratio": [],
                                  "m_ols": [], "b_ols": []}
         # mask long gaps option
-        sections = ["Fluxes", target, "GapFillUsingMDS", output]
+        sections = ["Fluxes", target, "GapFillUsingSOLO", output]
         opt = pfp_utils.get_keyvaluefromcf(cf, sections, "mask long gaps", default="Yes")
         so[output]["mask long gaps"] = True
         if opt.lower() == "no":

--- a/scripts/pfp_gf.py
+++ b/scripts/pfp_gf.py
@@ -280,7 +280,7 @@ def ParseL5ControlFile(cfg, ds):
             if ds.info["returncodes"]["value"] != 0:
                 return l5_info
         if "GapFillUsingMDS" in list(cfg["Fluxes"][label].keys()):
-            gfMDS_createdict(cfg, ds, l5_info, label, "GapFillUsingMDS", 530)
+            gfMDS_createdict(cfg, ds, l5_info, label, "GapFillUsingMDS", 570)
             if ds.info["returncodes"]["value"] != 0:
                 return l5_info
         if "MergeSeries" in list(cfg["Fluxes"][label].keys()):

--- a/scripts/pfp_gfALT.py
+++ b/scripts/pfp_gfALT.py
@@ -1028,9 +1028,6 @@ def gfalternate_plotcomposite(data_dict, stat_dict, diel_avg, l4a, pd):
     fig.savefig(figname, format='png')
     # draw the plot on the screen
     if l4a["gui"]["show_plots"]:
-        #plt.draw()
-        #pfp_utils.mypause(0.5)
-        #plt.ioff()
         fig.canvas.flush_events()
     else:
         plt.close()
@@ -1098,9 +1095,6 @@ def gfalternate_plotcoveragelines(ds_tower, l4_info, called_by):
     pylab.yticks(ylabel_posn, ylabel_right_list)
     fig.tight_layout()
     if l4a["gui"]["show_plots"]:
-        #plt.draw()
-        #pfp_utils.mypause(1)
-        #plt.ioff()
         fig.canvas.flush_events()
     else:
         plt.switch_backend(current_backend)
@@ -1193,9 +1187,6 @@ def gfalternate_plotsummary(l4_info):
         figname += "_" + startdate.strftime("%Y%m%d") + "_" + enddate.strftime("%Y%m%d") + ".png"
         fig.savefig(figname, format="png")
         if l4ig["show_plots"]:
-            #plt.draw()
-            #pfp_utils.mypause(1)
-            #plt.ioff()
             fig.canvas.flush_events()
         else:
             plt.close()

--- a/scripts/pfp_gfMDS.py
+++ b/scripts/pfp_gfMDS.py
@@ -283,6 +283,9 @@ def gfMDS_mask_long_gaps(ds, mds_label, l5_info, called_by):
     Author: PRI
     Date: June 2019
     """
+    if not l5_info[called_by]["outputs"][mds_label]["mask long gaps"]:
+        # mask long gaps disabled in control file
+        return
     if "MaxShortGapRecords" not in l5_info[called_by]["info"]:
         return
     max_short_gap_days = l5_info[called_by]["info"]["MaxShortGapDays"]

--- a/scripts/pfp_gfMDS.py
+++ b/scripts/pfp_gfMDS.py
@@ -423,9 +423,6 @@ def gfMDS_plot(pd, ds, mds_label, l5_info, called_by):
     figure_path = os.path.join(l5_info[called_by]["info"]["plot_path"], figure_name)
     fig.savefig(figure_path, format='png')
     if pd["show_plots"]:
-        #plt.draw()
-        #pfp_utils.mypause(1)
-        #plt.ioff()
         fig.canvas.flush_events()
     else:
         plt.close(fig)

--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -38,7 +38,7 @@ def GapFillUsingSOLO(main_gui, ds, l5_info, called_by):
     l5_info[called_by]["info"]["enddate"] = ldt[-1].strftime("%Y-%m-%d %H:%M")
     # are we running in interactive or batch mode?
     if l5_info[called_by]["info"]["call_mode"].lower() == "interactive":
-        l5_info["GapFillUsingSOLO"]["gui"]["show_plots"] = True
+        l5_info[called_by]["gui"]["show_plots"] = True
         # put up a plot of the data coverage at L4
         gfSOLO_plotcoveragelines(ds, l5_info, called_by)
         # call the GapFillUsingSOLO GUI

--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -519,11 +519,6 @@ def gfSOLO_plot(pd, ds, drivers, target, output, l5s, si=0, ei=-1):
     fig.savefig(figname, format="png")
     # draw the plot on the screen
     if l5s["gui"]["show_plots"]:
-        #plt.draw()
-        #plt.show()
-        #plt.pause(0.5)
-        #pfp_utils.mypause(5)
-        #plt.ioff()
         fig.canvas.flush_events()
     else:
         plt.close()
@@ -592,9 +587,6 @@ def gfSOLO_plotcoveragelines(ds, l5_info, called_by):
     ax2.set_yticklabels(ylabel_right_list)
     fig.tight_layout()
     if l5s["gui"]["show_plots"]:
-        #plt.draw()
-        #pfp_utils.mypause(1)
-        #plt.ioff()
         fig.canvas.flush_events()
     else:
         plt.switch_backend(current_backend)
@@ -678,9 +670,6 @@ def gfSOLO_plotsummary(ds, solo):
     figname = figname + "_" + sdt + "_" + edt + ".png"
     fig.savefig(figname, format="png")
     if solo["gui"]["show_plots"]:
-        #plt.draw()
-        #pfp_utils.mypause(0.5)
-        #plt.ioff()
         fig.canvas.flush_events()
     else:
         plt.close()

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -3742,7 +3742,7 @@ def xl_write_series(ds, xlfullname, outputlist=None):
         variablelist = list(ds.root["Variables"].keys())
         nRecs = len(ds.root["Variables"][variablelist[0]]["Data"])
     # open the Excel file
-    msg = " Opening and writing Excel file " + os.path.basename(xlfullname)
+    msg = " Opening and writing Excel file " + os.path.basename(xlfullname) + " (xlwt)"
     logger.info(msg)
     xlfile = xlwt.Workbook(encoding="latin-1")
     # set the datemode
@@ -3862,7 +3862,7 @@ def xlsx_write_series(ds, xlsxfullname, outputlist=None):
         variablelist = list(ds.root["Variables"].keys())
         nRecs = len(ds.root["Variables"][variablelist[0]]["Data"])
     # open the Excel file
-    msg = " Opening and writing Excel file " + os.path.basename(xlsxfullname)
+    msg = " Opening and writing Excel file " + os.path.basename(xlsxfullname) + " (xlsxwriter)"
     logger.info(msg)
     if "xl_datemode" not in ds.root["Attributes"]:
         if platform.system() == "darwin":

--- a/scripts/pfp_levels.py
+++ b/scripts/pfp_levels.py
@@ -286,6 +286,8 @@ def l5qc(main_gui, cf, ds4):
     pfp_gf.CheckL5Drivers(ds5, l5_info)
     if ds5.info["returncodes"]["value"] != 0:
         return ds5
+    # apply any QC checks
+    pfp_ck.do_qcchecks(cf, ds5)
     # now do the flux gap filling methods
     # *** start of the section that does the gap filling of the fluxes ***
     pfp_gf.CheckGapLengths(cf, ds5, l5_info)

--- a/scripts/pfp_part.py
+++ b/scripts/pfp_part.py
@@ -581,9 +581,6 @@ class partition(object):
         fig.savefig(file_name, format="png")
 
         if self.l6_info["Options"]["call_mode"] == "interactive":
-            #plt.draw()
-            #pfp_utils.mypause(1)
-            #plt.ioff()
             fig.canvas.flush_events()
         else:
             plt.close()
@@ -629,9 +626,6 @@ class partition(object):
         fig.savefig(file_name, format="png")
 
         if self.l6_info["Options"]["call_mode"] == "interactive":
-            #plt.draw()
-            #pfp_utils.mypause(1)
-            #plt.ioff()
             fig.canvas.flush_events()
         else:
             plt.close()

--- a/scripts/pfp_plot.py
+++ b/scripts/pfp_plot.py
@@ -84,9 +84,6 @@ def checktimestamps_plots(df, sheet, l1_info):
     # interactive or batch?
     if show_plots.lower() == "yes":
         # interactive so render the plot, pause 0.5 seconds, turn interactive plotting off
-        #plt.draw()
-        #pfp_utils.mypause(1)
-        #plt.ioff()
         fig.canvas.flush_events()
     else:
         # batch so close the figure, switch to previous backend
@@ -617,9 +614,6 @@ def plot_fingerprint(cf):
         pngname = pngname + title.replace(" ", "_") + ".png"
         fig.savefig(pngname, format="png")
         if show_plots:
-            #plt.draw()
-            #pfp_utils.mypause(1)
-            #plt.ioff()
             fig.canvas.flush_events()
         else:
             plt.close(fig)

--- a/scripts/pfp_rp.py
+++ b/scripts/pfp_rp.py
@@ -553,9 +553,6 @@ def L6_summary_plotdaily(ds_summary, l6_info):
         figure_path = os.path.join(plot_path, figure_name)
         fig.savefig(figure_path, format='png')
         if l6_info["Options"]["call_mode"].lower() == "interactive":
-            #plt.draw()
-            #pfp_utils.mypause(1)
-            #plt.ioff()
             fig.canvas.flush_events()
         else:
             plt.close(fig)
@@ -590,9 +587,6 @@ def L6_summary_plotdaily(ds_summary, l6_info):
     figname = figname+"_"+sdt+"_"+edt+'.png'
     fig.savefig(figname,format='png')
     if l6_info["Options"]["call_mode"].lower()=="interactive":
-        #plt.draw()
-        #pfp_utils.mypause(1)
-        #plt.ioff()
         fig.canvas.flush_events()
     else:
         plt.close(fig)
@@ -708,9 +702,6 @@ def L6_summary_plotcumulative(ds_summary, l6_info):
         figure_path = os.path.join(plot_path, figure_name)
         fig.savefig(figure_path, format='png')
         if l6_info["Options"]["call_mode"].lower() == "interactive":
-            #plt.draw()
-            #pfp_utils.mypause(1)
-            #plt.ioff()
             fig.canvas.flush_events()
         else:
             plt.close(fig)
@@ -2324,9 +2315,6 @@ def rp_plot(pd, ds, output, drivers, target, iel, called_by, si=0, ei=-1):
     fig.savefig(figname, format='png')
     # draw the plot on the screen
     if iel["gui"]["show_plots"]:
-        #plt.draw()
-        #pfp_utils.mypause(1)
-        #plt.ioff()
         fig.canvas.flush_events()
     else:
         #plt.close(fig)

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -2786,10 +2786,6 @@ def MergeSeriesUsingDict(ds, info, merge_order="standard"):
                 index = numpy.where(numpy.mod(flag1, 10) == 0)[0]
                 # set them all to 0
                 flag2[index] = 0
-                if label=="Fg":
-                    index = numpy.where(flag2 == 22)[0]
-                    if len(index) != 0:
-                        flag2[index] = 0
                 # index of flag values other than 0,10,20,30 ...
                 index = numpy.where(flag2 != 0)[0]
                 # replace bad primary with good secondary


### PR DESCRIPTION
Implemented MAD filter at L5 so spike removal can be done before gap filling fluxes.

Replaced plt.draw()/pfp_utils.mypause() with fig.canvas.flush_events() so that plots at L4 and L5 display correctly.  Previously, only the window title changed, the plots only updated for the last variable in the loop.

Discovered that the business code for masking long gaps after filling with SOLO wasn't implemented in the main branch.  The code was there for MDS but not SOLO and even the MDS code  for masking long gaps didn't get called correctly.  Fixed the masking of long gaps for MDS and implemented same for SOLO.  Checked with Dry River to confirm long gaps (default 30 days) are now masked after both MDS and SOLO and then filled with results from GapFillLongSOLO().

Tested branch on Dry River and Examples/, confirmed long gap filling correct with Dry River.