### PR TITLE
Qc flag for imports

### DIFF
--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -573,12 +573,10 @@ def ParseL3ControlFile(cfg, ds):
     # PRI 7/10/2021 the code to get zms will give unpredictable results if CO2
     #   profile data present
     l3_info = {"status": {"value": 0, "message": "OK", "ok": True},
-               "cfg": {},
                "variables": {"CO2": {}, "Fco2": {}, "Sco2": {}},
                "CombineSeries": {}}
-    # copy the control file sections to the l3_info dictionary
-    for section in list(cfg.keys()):
-        l3_info["cfg"][section] = copy.deepcopy(cfg[section])
+    # copy the control file into the l3_info dictionary
+    l3_info["cfg"] = copy.deepcopy(cfg)
     # add key for suppressing output of intermediate variables e.g. Cpd etc
     opt = pfp_utils.get_keyvaluefromcf(cfg, ["Options"], "KeepIntermediateSeries", default="No")
     l3_info["RemoveIntermediateSeries"] = {"KeepIntermediateSeries": opt, "not_output": []}

--- a/scripts/pfp_gf.py
+++ b/scripts/pfp_gf.py
@@ -1317,6 +1317,9 @@ def ImportSeries(ds, info):
     if "Imports" not in list(cfg.keys()):
         return
     info["ImportSeries"] = {}
+    # processing level
+    level = ds.root["Attributes"]["processing_level"]
+    qc_prefix = 100 * int(pfp_utils.strip_non_numeric(level))
     # number of records
     nrecs = int(ds.root["Attributes"]["nc_nrecs"])
     # get the start and end datetime
@@ -1359,7 +1362,7 @@ def ImportSeries(ds, info):
         indainb, indbina = pfp_utils.FindMatchingIndices(ldt_import, ldt)
         var = pfp_utils.CreateEmptyVariable(label, nrecs, attr=var_import["Attr"])
         var["Data"][indbina] = var_import["Data"][indainb]
-        var["Flag"][indbina] = var_import["Flag"][indainb]
+        var["Flag"][indbina] = var_import["Flag"][indainb] + qc_prefix
         pfp_utils.CreateVariable(ds, var)
         info["ImportSeries"][label] = {"start": ldt[indbina[0]],
                                        "end": ldt[indbina[-1]]}


### PR DESCRIPTION
pfp_gf.ImportSeries() now uses the processing level times 100 as the QC flag prefix for imported data.  For example, data imported at L3 uses 300 as the prefix, data imported at L4 uses 400 etc.  This allows the user to diagnose what data has been imported at what level.