### PR TITLE
Don't enforce update or compliance checks on L1 nc2csv_oneflux runs.

### DIFF
--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -372,7 +372,7 @@ class pfp_main_ui(QWidget):
             # and save the control file
             self.file.write()
         # create a QtTreeView to edit the control file
-        if self.file["level"] in ["L1"]:
+        if self.file["level"].split("_")[0] in ["L1"]:
             # update control file to new syntax
             if not pfp_compliance.l1_update_controlfile(self.file): return
             # put the GUI for editing the L1 control file in a new tab
@@ -788,7 +788,7 @@ class pfp_main_ui(QWidget):
             self.threadpool.start(worker)
             # no threading
             #pfp_top_level.do_run_batch(self)
-        elif cfg["level"] == "L1":
+        elif cfg["level"].split("_")[0] == "L1":
             # check the L1 control file to see if it is OK to run
             if pfp_compliance.check_l1_controlfile(cfg):
                 pfp_top_level.do_run_l1(cfg)

--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -737,9 +737,12 @@ def check_l1_controlfile(cfg):
     Author: PRI
     Date: October 2021
     """
+    ok = True
+    # compliance checks not applied for L1 nc2csv_oneflux
+    if cfg["level"] in ["L1_oneflux"]:
+        return ok
     # quick and dirty use of try...except in a panic ahead to 2021 workshop
     try:
-        ok = True
         cfg_labels = sorted(list(cfg["Variables"].keys()))
         base_path = pfp_utils.get_base_path()
         std_name = os.path.join(base_path, "controlfiles", "standard", "check_l1_controlfile.txt")
@@ -1910,6 +1913,11 @@ def l1_update_controlfile(cfg):
     Author: PRI
     Date: February 2020
     """
+    # initialise the return logical
+    ok = True
+    # update control file not applied for L1 nc2csv_oneflux
+    if cfg["level"] in ["L1_oneflux"]:
+        return ok
     # copy the control file
     cfg_original = copy.deepcopy(cfg)
     # check to see if we can load the update_control_files.txt standard control file
@@ -1932,8 +1940,6 @@ def l1_update_controlfile(cfg):
     except Exception:
         ok = False
         msg = " Unable to load standard control file " + chkname
-    # initialise the return logical
-    ok = True
     try:
         cfg = update_cfg_syntax(cfg, std)
     except Exception:

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -1418,7 +1418,7 @@ class edit_cfg_L1(QtWidgets.QWidget):
         """ Iterate over the model and get the data."""
         cfg = ConfigObj(indent_type="    ", list_values=False)
         cfg.filename = self.cfg.filename
-        cfg["level"] = "L1"
+        cfg["level"] = self.cfg["level"]
         model = self.model
         # there must be a way to do this recursively
         for i in range(model.rowCount()):


### PR DESCRIPTION
The conversion of ONEFlux CSV output files to netCDF using PFP L1 was generating a lot of warnings and error s from the L1 control file update and compliance check processes.  A sub-type of L1 called "L1_oneflux" is now used in the nc2csv_oneflux control file and updates and compliance checks are not applied to this su-type.