### PR TITLE
Fix irga type l3

### DIFF
--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -1052,7 +1052,7 @@ def check_l3_options_generic(cfg, messages):
         if Fco2_units not in ["umol/m^2/s", "mg/m^2/s"]:
             msg = "Unrecognised Fco2 units (" + Fco2_units + "), must be umol/m^2/s or mg/m^2/s"
             messages["ERROR"].append(msg)
-    for item in ["2DCoordRotation", "ApplyFco2Storage", "ApplyWPL", "CalculateFluxes",
+    for item in ["2DCoordRotation", "ApplyFco2Storage", "CalculateFluxes",
                  "CorrectFgForStorage", "CorrectIndividualFg", "KeepIntermediateSeries",
                  "MassmanCorrection", ]:
         if item in cfg["Options"]:
@@ -2672,22 +2672,6 @@ def update_cfg_options(cfg, std):
                 cfg["Options"].rename(item, item.replace("Fc", "Fco2"))
             if item in ["CcUnits"]:
                 cfg["Options"].rename(item, item.replace("Cc", "CO2"))
-        if "DisableFco2WPL" in list(cfg["Options"].keys()):
-            opt = cfg["Options"]["DisableFco2WPL"]
-            if opt.lower() == "no":
-                apply_wpl = "Yes"
-            else:
-                apply_wpl = "No"
-            cfg["Options"].pop("DisableFco2WPL")
-            cfg["Options"]["ApplyWPL"] = apply_wpl
-        if "DisableFeWPL" in list(cfg["Options"].keys()):
-            opt = cfg["Options"]["DisableFeWPL"]
-            if opt.lower() == "no":
-                apply_wpl = "Yes"
-            else:
-                apply_wpl = "No"
-            cfg["Options"].pop("DisableFeWPL")
-            cfg["Options"]["ApplyWPL"] = apply_wpl
         if "UseL2Fluxes" in list(cfg["Options"].keys()):
             opt = cfg["Options"]["UseL2Fluxes"]
             if opt.lower() == "no":
@@ -2696,6 +2680,11 @@ def update_cfg_options(cfg, std):
                 calculate_fluxes = "No"
             cfg["Options"].pop("UseL2Fluxes")
             cfg["Options"]["CalculateFluxes"] = calculate_fluxes
+        # remove deprecated L3 options
+        for item in ["DisableFco2WPL", "DisableFcWPL", "DisableFeWPL",
+                     "DisableWPL", "ApplyWPL"]:
+            if item in cfg["Options"]:
+                cfg["Options"].pop(item)
         old_units = list(std["Variables"]["units_map"].keys())
         for item in list(cfg["Options"].keys()):
             if cfg["Options"][item] in old_units:

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -3123,14 +3123,6 @@ class edit_cfg_L3(QtWidgets.QWidget):
         self.add_qc_check(selected_item, new_qc)
         self.update_tab_text()
 
-    def add_ApplyWPL_to_options(self):
-        """ Add ApplyWPL to the [Options] section."""
-        child0 = QtGui.QStandardItem("ApplyWPL")
-        child0.setEditable(False)
-        child1 = QtGui.QStandardItem("Yes")
-        self.sections["Options"].appendRow([child0, child1])
-        self.update_tab_text()
-
     def add_diurnalcheck(self):
         """ Add a diurnal check to a variable."""
         new_qc = {"DiurnalCheck":{"numsd":"5"}}
@@ -3721,11 +3713,6 @@ class edit_cfg_L3(QtWidgets.QWidget):
                     self.context_menu.actionAddApplyFco2Storage.setText("ApplyFco2Storage")
                     self.context_menu.addAction(self.context_menu.actionAddApplyFco2Storage)
                     self.context_menu.actionAddApplyFco2Storage.triggered.connect(self.add_applyfco2storage_to_options)
-                if "ApplyWPL" not in existing_entries:
-                    self.context_menu.actionAddApplyWPL = QtWidgets.QAction(self)
-                    self.context_menu.actionAddApplyWPL.setText("ApplyWPL")
-                    self.context_menu.addAction(self.context_menu.actionAddApplyWPL)
-                    self.context_menu.actionAddApplyWPL.triggered.connect(self.add_ApplyWPL_to_options)
                 if "CalculateFluxes" not in existing_entries:
                     self.context_menu.actionAddCalculateFluxes = QtWidgets.QAction(self)
                     self.context_menu.actionAddCalculateFluxes.setText("CalculateFluxes")
@@ -3838,10 +3825,9 @@ class edit_cfg_L3(QtWidgets.QWidget):
                     self.context_menu.addAction(self.context_menu.actionRemoveOption)
                     self.context_menu.actionRemoveOption.triggered.connect(self.remove_item)
                 elif (selected_item.column() == 1) and (key in ["2DCoordRotation", "ApplyFco2Storage",
-                                                                "ApplyWPL", "CalculateFluxes",
-                                                                "CorrectIndividualFg", "CorrectFgForStorage",
-                                                                "KeepIntermediateSeries", "MassmanCorrection",
-                                                                "UseFhvforFh"]):
+                                                                "CalculateFluxes", "CorrectIndividualFg",
+                                                                "CorrectFgForStorage", "KeepIntermediateSeries",
+                                                                "MassmanCorrection", "UseFhvforFh"]):
                     if selected_text != "Yes":
                         self.context_menu.actionChangeOption = QtWidgets.QAction(self)
                         self.context_menu.actionChangeOption.setText("Yes")

--- a/scripts/pfp_levels.py
+++ b/scripts/pfp_levels.py
@@ -143,11 +143,11 @@ def l3qc(cf, ds2):
         # approximate wT from virtual wT using wA (ref: Campbell OPECSystem manual)
         pfp_ts.FhvtoFh(cf, ds3)
         # correct the H2O & CO2 flux due to effects of flux on density measurements
-        if pfp_ts.Fe_WPL(cf, ds3):
+        pfp_ts.Fe_WPL(cf, ds3)
+        if ds3.info["returncodes"]["value"] != 0:
             return ds3
-        #if pfp_ts.Fco2_WPL(cf, ds3):
-            #return ds3
-        if not pfp_ts.Fco2_WPL(cf, ds3):
+        pfp_ts.Fco2_WPL(cf, ds3)
+        if ds3.info["returncodes"]["value"] != 0:
             return ds3
     # **************************
     # *** CO2 and Fc section ***

--- a/scripts/pfp_levels.py
+++ b/scripts/pfp_levels.py
@@ -145,7 +145,9 @@ def l3qc(cf, ds2):
         # correct the H2O & CO2 flux due to effects of flux on density measurements
         if pfp_ts.Fe_WPL(cf, ds3):
             return ds3
-        if pfp_ts.Fco2_WPL(cf, ds3):
+        #if pfp_ts.Fco2_WPL(cf, ds3):
+            #return ds3
+        if not pfp_ts.Fco2_WPL(cf, ds3):
             return ds3
     # **************************
     # *** CO2 and Fc section ***


### PR DESCRIPTION
Fixing bug in pfp_ts.Fco2_WPL() and pfp_ts.Fe_WPL() that caused WPL correction to be applied to closed path IRGAs if the ApplyWPL option at L3 was set to "No".  Bad Peter ...
Deprecated the ApplyWPL option at L3.  WPL correction applied only if irga_type is in open_path_irgas.  If irga_type is in closed_path_irgas then the routines exit with a logger INFO message.  If irga_type is not in either open_path_irgas or closed_path_irgas then the routines exit with an error message.