### PR TITLE
Smarter l3

### DIFF
--- a/scripts/pfp_compliance.py
+++ b/scripts/pfp_compliance.py
@@ -620,7 +620,8 @@ def parse_l3_co2_label(info):
     if "CO2" in list(info["cfg"]["Variables"].keys()):
         info["variables"]["CO2"]["label"] = "CO2"
     else:
-        msg = " Label for CO2 not found in control file"
+        info["variables"]["CO2"]["label"] = None
+        msg = " No entry for CO2 in control file"
         logger.warning(msg)
         info["status"]["value"] = 1
         info["status"]["message"] = msg
@@ -628,6 +629,8 @@ def parse_l3_co2_label(info):
 
 def parse_l3_co2_height(ds, info):
     """ Get the height of the CO2 measurement from various sources."""
+    if info["variables"]["CO2"]["label"] is None:
+        return
     cfg = info["cfg"]
     got_zms = False
     labels = list(ds.root["Variables"].keys())
@@ -1088,6 +1091,10 @@ def check_l3_options_rotation(cfg, messages):
     return
 def check_l3_options_soil(cfg, messages):
     """ Check the entries of the Soil section."""
+    if "Soil" not in list(cfg.keys()):
+        msg = "No [Soil] section in control file"
+        messages["WARNING"].append(msg)
+        return
     # check the numbers
     for item in ["BulkDensity", "OrganicContent"]:
         if item in cfg["Soil"]:

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -368,23 +368,34 @@ def CalculateHumidities(ds):
      March 2015
     Author: PRI
     """
-    msg = " Calculating humidities"
-    logger.info(msg)
     if "AH" not in list(ds.root["Variables"].keys()):
         if "SH" in list(ds.root["Variables"].keys()):
+            msg = " Calculating absolute humidity from specific humidity"
+            logger.info(msg)
             AbsoluteHumidityFromSpecificHumidity(ds)   # calculate AH from SH
         elif "RH" in list(ds.root["Variables"].keys()):
+            msg = " Calculating absolute humidity from relative humidity"
+            logger.info(msg)
             AbsoluteHumidityFromRelativeHumidity(ds)   # calculate AH from RH
     if "SH" not in list(ds.root["Variables"].keys()):
         if "AH" in list(ds.root["Variables"].keys()):
+            msg = " Calculating specific humidity from absolute humidity"
+            logger.info(msg)
             SpecificHumidityFromAbsoluteHumidity(ds)
         elif "RH" in list(ds.root["Variables"].keys()):
+            msg = " Calculating specific humidity from relative humidity"
+            logger.info(msg)
             SpecificHumidityFromRelativeHumidity(ds)
     if "RH" not in list(ds.root["Variables"].keys()):
         if "AH" in list(ds.root["Variables"].keys()):
+            msg = " Calculating relative humidity from absolute humidity"
+            logger.info(msg)
             RelativeHumidityFromAbsoluteHumidity(ds)
         elif "SH" in list(ds.root["Variables"].keys()):
+            msg = " Calculating relative humidity from specific humidity"
+            logger.info(msg)
             RelativeHumidityFromSpecificHumidity(ds)
+    return
 
 def CalculateHumiditiesAfterGapFill(ds, info):
     """
@@ -2900,7 +2911,8 @@ def MergeSeriesUsingDict(ds, info, merge_order="standard"):
 
 def MergeHumidities(cf, ds, convert_units=False):
     if "AH" not in cf["Variables"] and "RH" not in cf["Variables"] and "SH" not in cf["Variables"]:
-        logger.error(" MergeHumidities: No humidities found in control file, returning ...")
+        msg = " MergeHumidities: No humidities found in control file, returning ..."
+        logger.warning(msg)
         return
     if "AH" in cf["Variables"]:
         if "MergeSeries" in cf["Variables"]["AH"]:
@@ -3173,6 +3185,11 @@ def TaFromTv(cf, ds, Ta_out="Ta_SONIC_Av", Tv_in="Tv_SONIC_Av", AH_in="AH",
     # NOTE: the virtual temperature is used in place of the air temperature
     #       to calculate the vapour pressure from the absolute humidity, the
     #       approximation involved here is of the order of 1%.
+    labels = list(ds.root["Variables"].keys())
+    if Ta_out in labels:
+        msg = " TaFromTv: Ta_SONIC_Av already in data structure"
+        logger.warning(msg)
+        return
     logger.info(" Calculating Ta from Tv")
     nRecs = int(ds.root["Attributes"]["nc_nrecs"])
     ones = numpy.ones(nRecs)
@@ -3181,17 +3198,16 @@ def TaFromTv(cf, ds, Ta_out="Ta_SONIC_Av", Tv_in="Tv_SONIC_Av", AH_in="AH",
     Ta = pfp_utils.CreateEmptyVariable(Ta_out, nRecs)
     # check to see if we have enough data to proceed
     # deal with possible aliases for the sonic temperature
-    if Tv_in not in list(ds.root["Variables"].keys()):
+    if Tv_in not in labels:
         msg = " TaFromTv: sonic virtual temperature not found in data structure"
         logger.error(msg)
         return
-    if ((AH_in not in list(ds.root["Variables"].keys())) and (RH_in not in list(ds.root["Variables"].keys())) and
-        (SH_in not in list(ds.root["Variables"].keys()))):
+    if ((AH_in not in labels) and (RH_in not in labels) and (SH_in not in labels)):
         labstr = str(AH_in) + "," + str(RH_in) + "," + str(SH_in)
         msg = " TaFromTv: no humidity data (" + labstr + ") found in data structure"
         logger.error(msg)
         return
-    if ps_in not in list(ds.root["Variables"].keys()):
+    if ps_in not in labels:
         msg = " TaFromTv: pressure (" + str(ps_in) + ") not found in data structure"
         logger.error(msg)
         return

--- a/scripts/pfp_ts.py
+++ b/scripts/pfp_ts.py
@@ -370,30 +370,18 @@ def CalculateHumidities(ds):
     """
     if "AH" not in list(ds.root["Variables"].keys()):
         if "SH" in list(ds.root["Variables"].keys()):
-            msg = " Calculating absolute humidity from specific humidity"
-            logger.info(msg)
             AbsoluteHumidityFromSpecificHumidity(ds)   # calculate AH from SH
         elif "RH" in list(ds.root["Variables"].keys()):
-            msg = " Calculating absolute humidity from relative humidity"
-            logger.info(msg)
             AbsoluteHumidityFromRelativeHumidity(ds)   # calculate AH from RH
     if "SH" not in list(ds.root["Variables"].keys()):
         if "AH" in list(ds.root["Variables"].keys()):
-            msg = " Calculating specific humidity from absolute humidity"
-            logger.info(msg)
             SpecificHumidityFromAbsoluteHumidity(ds)
         elif "RH" in list(ds.root["Variables"].keys()):
-            msg = " Calculating specific humidity from relative humidity"
-            logger.info(msg)
             SpecificHumidityFromRelativeHumidity(ds)
     if "RH" not in list(ds.root["Variables"].keys()):
         if "AH" in list(ds.root["Variables"].keys()):
-            msg = " Calculating relative humidity from absolute humidity"
-            logger.info(msg)
             RelativeHumidityFromAbsoluteHumidity(ds)
         elif "SH" in list(ds.root["Variables"].keys()):
-            msg = " Calculating relative humidity from specific humidity"
-            logger.info(msg)
             RelativeHumidityFromSpecificHumidity(ds)
     return
 

--- a/scripts/pfp_utils.py
+++ b/scripts/pfp_utils.py
@@ -312,6 +312,7 @@ def ConvertCO2Units(cf, ds):
                     msg = " Converting " + label + " from " + CO2_in["Attr"]["units"] + " to mmol/m^3"
                     logger.info(msg)
                     CO2_out = convert_units_func(ds, CO2_in, "mmol/m^3")
+                    CreateVariable(ds, CO2_out)
                 else:
                     continue
         elif (label[-3:] == "_Vr"):
@@ -325,6 +326,7 @@ def ConvertCO2Units(cf, ds):
                     CO2_out = convert_units_func(ds, CO2_in, "mmol/m^3")
                     CO2_out["Data"] = CO2_out["Data"]*CO2_out["Data"]
                     CO2_out["Attr"]["units"] = "mmol^2/m^6"
+                    CreateVariable(ds, CO2_out)
                 else:
                     continue
         elif ((CO2_units_in in ["mg/m^3"]) and (CO2_units_out == "umol/mol")):
@@ -333,11 +335,11 @@ def ConvertCO2Units(cf, ds):
             msg += " to " + CO2_units_out
             logger.info(msg)
             CO2_out = convert_units_func(ds, CO2_in, CO2_units_out)
+            CreateVariable(ds, CO2_out)
         else:
             msg = " Unrecognised conversion for " + label
-            msg += "(" + CO2_units_in + " to " + CO2_units_out + ")"
+            msg += " (" + CO2_units_in + " to " + CO2_units_out + ")"
             logger.error(msg)
-        CreateVariable(ds, CO2_out)
     return
 
 def ConvertFco2Units(cf, ds):


### PR DESCRIPTION
Changes so that L3 will run with non-standard variables.  The intent is to allow reprocessing of L3 with limited variables, the example is reprocessing Ridgefield to remove Sws_5cm as the basis for Sws.  L3 processing will now run without requiring standard variables such as CO2, AH, RH, SH etc.
Tested with batch run of Examples.