### PR TITLE
Updated codes for times and frequencies that have deprecated in Panda…

### DIFF
--- a/controlfiles/templates/L1/L1_ozflux_csv.txt
+++ b/controlfiles/templates/L1/L1_ozflux_csv.txt
@@ -527,3 +527,6 @@ and the Education Investment Fund.'''
             units = kPa
         [[[csv]]]
             name = ps_7500_Avg
+[Options]
+    call_mode = interactive
+    show_plots = Yes

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - pyqt
   - pytz
   - scipy<=1.15.3
-  - statsmodels==0.14.4
+  - statsmodels
   - timezonefinder
   - windrose
   - xarray

--- a/scripts/pfp_cpd_mcnew.py
+++ b/scripts/pfp_cpd_mcnew.py
@@ -745,7 +745,7 @@ def _write_to_file(data_dict, write_to_file):
             for year in df.Year.unique():
                 (df.loc[df.Year==year]
                  .drop('Year', axis=1)
-                 .to_excel(xlwriter, sheet_name=str(year), index=None)
+                 .to_excel(excel_writer=xlwriter, sheet_name=str(year), index=None)
                  )
             continue
     xlwriter.close()

--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -433,7 +433,7 @@ def gfSOLO_plot(pd, ds, drivers, target, output, l5s, si=0, ei=-1):
     # plot the best fit line
     coefs = numpy.ma.polyfit(numpy.ma.copy(mod["Data"]), numpy.ma.copy(obs["Data"]), 1)
     xfit = numpy.ma.array([numpy.ma.min(mod["Data"]), numpy.ma.max(mod["Data"])], copy=True)
-    yfit = numpy.polyval(coefs, xfit)
+    yfit = numpy.polyval(coefs,xfit)
     r = numpy.ma.corrcoef(mod["Data"], obs["Data"])
     ax2.plot(xfit, yfit, 'r--', linewidth=3)
     eqnstr = 'y = %.3fx + %.3f, r = %.3f'%(coefs[0], coefs[1], r[0][1])

--- a/scripts/pfp_io.py
+++ b/scripts/pfp_io.py
@@ -867,7 +867,7 @@ def ReadExcelWorkbook(l1_info):
         # set the data frame index to the time stamp
         dfs[df_name].set_index(timestamp, inplace=True)
         # round the datetime index to the nearest second
-        dfs[df_name].index = dfs[df_name].index.round('1S')
+        dfs[df_name].index = dfs[df_name].index.round('1s')
         # drop columns except those wanted by the user
         dfs[df_name] = dfs[df_name][~dfs[df_name].index.duplicated(keep='first')]
         # drop columns except those wanted by the user
@@ -2670,7 +2670,7 @@ def MergeDataFrames(dfs, l1_info):
             start = min([min(dfs[df_name].index.values), start])
             end = max([max(dfs[df_name].index.values), end])
         # get the timestep as a string pandas will recognise
-        ts = str(int(l1_info["read_excel"]["Global"]["time_step"])) + "T"
+        ts = str(int(l1_info["read_excel"]["Global"]["time_step"])) + "min"
         # create a pandas datetime range
         dt = pandas.date_range(start, end, freq=ts)
         # create an empty data frame

--- a/scripts/pfp_mpt.py
+++ b/scripts/pfp_mpt.py
@@ -226,7 +226,7 @@ def xl_write_mpt(mpt_full_path, ustar_results):
     xlwriter = pandas.ExcelWriter(mpt_full_path)
     df_annual = pandas.DataFrame.from_dict(annual, orient='index')
     df_annual.index.names = ["Year"]
-    df_annual.to_excel(xlwriter, sheet_name='Annual')
+    df_annual.to_excel(excel_writer= xlwriter, sheet_name='Annual')
     by_years = {}
     for year in years:
         by_years["Seasonal"] = {"Values": ustar_results["Years"][year]["seasonal"]["value"],

--- a/scripts/pfp_part.py
+++ b/scripts/pfp_part.py
@@ -253,7 +253,7 @@ class partition(object):
                 # delete the attribute
                 delattr(self, "LL_fignum")
         E0_results = pd.DataFrame.from_dict(self.results["E0"], orient="index")
-        E0_results.to_excel(self.xl_writer, "E0 results")
+        E0_results.to_excel(excel_writer =self.xl_writer, sheet_name = "E0 results")
         if len(Eo_list) == 0:
             msg = "***** Could not find any valid estimates of E0, exiting..."
             logger.warning(msg)
@@ -359,8 +359,8 @@ class partition(object):
         out_df = pd.DataFrame(result_list, index = date_list)
         out_df = out_df.resample('D').interpolate()
         out_df = out_df.reindex(np.unique(self.df.index.date))
-        out_df.fillna(method = 'bfill', inplace = True)
-        out_df.fillna(method = 'ffill', inplace = True)
+        out_df.bfill(inplace = True)
+        out_df.ffill( inplace = True)
         return out_df.join(flag)
     #--------------------------------------------------------------------------
 

--- a/scripts/pfp_rp.py
+++ b/scripts/pfp_rp.py
@@ -8,6 +8,7 @@ import os
 import dateutil
 import matplotlib.pyplot as plt
 import numpy
+from numpy.polynomial import Polynomial # NL: old polynomial API seems to be behaving strangely, trying this out.
 import pandas
 import pylab
 # PFP modules
@@ -269,7 +270,7 @@ def EcoResp(ds, l6_info, called_by, xl_writer):
         ER["Attr"]["comment1"] = "Drivers were {}".format(str(drivers))
         pfp_utils.CreateVariable(ds, ER)
         # Write to excel
-        params_df.to_excel(xl_writer, output)
+        params_df.to_excel(excel_writer = xl_writer, sheet_name = output)
         xl_writer.close()
         # Do plotting
         startdate = str(ds.root["Variables"]["DateTime"]["Data"][0])
@@ -2239,11 +2240,11 @@ def rp_plot(pd, ds, output, drivers, target, iel, called_by, si=0, ei=-1):
     ax2.set_ylabel(target + '_obs')
     ax2.set_xlabel(target + '_' + mode)
     # plot the best fit line
-    coefs = numpy.ma.polyfit(numpy.ma.copy(mod["Data"]), numpy.ma.copy(obs["Data"]), 1)
+    coefs = Polynomial.fit(numpy.ma.copy(mod["Data"].astype('float')), numpy.ma.copy(obs["Data"].astype('float')), 1).convert().coef
     xfit = numpy.ma.array([numpy.ma.minimum.reduce(mod["Data"]),
-                           numpy.ma.maximum.reduce(mod["Data"])], copy=True)
-    yfit = numpy.polyval(coefs, xfit)
-    r = numpy.ma.corrcoef(mod["Data"], obs["Data"])
+                           numpy.ma.maximum.reduce(mod["Data"]).astype('float')], copy=True)
+    yfit = numpy.polyval(xfit,coefs)
+    r = numpy.ma.corrcoef(mod["Data"].astype('float'), obs["Data"].astype('float'))
     ax2.plot(xfit, yfit, 'r--', linewidth=3)
     eqnstr = 'y = %.3fx + %.3f, r = %.3f'%(coefs[0], coefs[1], r[0][1])
     ax2.text(0.5, 0.875, eqnstr, fontsize=8, horizontalalignment='center', transform=ax2.transAxes)
@@ -2253,7 +2254,7 @@ def rp_plot(pd, ds, output, drivers, target, iel, called_by, si=0, ei=-1):
     diff = mod["Data"] - obs["Data"]
     bias = numpy.ma.average(diff)
     ielo[output]["results"]["Bias"].append(bias)
-    rmse = numpy.ma.sqrt(numpy.ma.mean((obs["Data"]-mod["Data"])*(obs["Data"]-mod["Data"])))
+    rmse = numpy.ma.sqrt(numpy.ma.mean((obs["Data"].astype('float')-mod["Data"].astype('float'))*(obs["Data"].astype('float')-mod["Data"]).astype('float')))
     plt.figtext(0.725, 0.225, 'No. points')
     plt.figtext(0.825, 0.225, str(numpoints))
     ielo[output]["results"]["No. points"].append(numpoints)
@@ -2276,8 +2277,8 @@ def rp_plot(pd, ds, output, drivers, target, iel, called_by, si=0, ei=-1):
     var_mod = numpy.ma.var(mod["Data"])
     ielo[output]["results"]["Var (" + mode + ")"].append(var_mod)
     ielo[output]["results"]["Var ratio"].append(var_obs/var_mod)
-    ielo[output]["results"]["Avg (obs)"].append(numpy.ma.average(obs["Data"]))
-    ielo[output]["results"]["Avg (" + mode + ")"].append(numpy.ma.average(mod["Data"]))
+    ielo[output]["results"]["Avg (obs)"].append(numpy.ma.average(obs["Data"]).astype('float'))
+    ielo[output]["results"]["Avg (" + mode + ")"].append(numpy.ma.average(mod["Data"].astype('float')))
     # time series of drivers and target
     ts_axes = []
     rect = [pd["margin_left"], pd["ts_bottom"], pd["ts_width"], pd["ts_height"]]

--- a/scripts/pfp_utils.py
+++ b/scripts/pfp_utils.py
@@ -2218,7 +2218,8 @@ def get_diurnalstats(dt,data,info):
         ei = ei - 1
     data_wholedays = data[si:ei+1]
     ndays = len(data_wholedays)//nperday
-    data_2d = numpy.ma.reshape(data_wholedays,[ndays,nperday])
+    data_2d =  numpy.ma.reshape(data_wholedays,new_shape =[ndays,nperday])
+    data_2d = data_2d.astype('float64')
     diel_stats = {}
     diel_stats["Hr"] = numpy.ma.array([i*ts/float(60) for i in range(0,nperday)], copy=True)
     diel_stats["Av"] = numpy.ma.average(data_2d,axis=0)


### PR DESCRIPTION
changed the codes for frequencies that have deprecated in pandas 3.0.0 and updated calls of read_excel to have one positional argument only (as changed in pandas 3.0.0). Assosciated with the changes in pandas version, errors in the behaviour of polyfit in the partitioning script came up. I don't know what the root cause was but it was fixed by changing to the newer numpy.polynomial.polynomial interface resolved the issue. 